### PR TITLE
Add Edge API references for getLocationHint and setLocationHint

### DIFF
--- a/src/pages/documentation/edge-network-extensions/api-reference.md
+++ b/src/pages/documentation/edge-network-extensions/api-reference.md
@@ -16,19 +16,19 @@ iOS (AEP 3.x)
 
 <Tabs query="platform=ios-aep&api=extension-version"/>
 
-## sendEvent
+## getLocationHint
 
-Sends an Experience event to Adobe Experience Platform Edge Network.
+Gets the Edge Network location hint used in requests to the Adobe Experience Platform Edge Network. The Edge Network location hint may be used when building the URL for Adobe Experience Platform Edge Network requests to hint at the server cluster to use.
 
 <TabsBlock orientation="horizontal" slots="heading, content" repeat="2"/>
 
 Android
 
-<Tabs query="platform=android&api=send-event"/>
+<Tabs query="platform=android&api=get-location-hint"/>
 
 iOS (AEP 3.x)
 
-<Tabs query="platform=ios-aep&api=send-event"/>
+<Tabs query="platform=ios-aep&api=get-location-hint"/>
 
 ## registerExtension
 
@@ -49,6 +49,37 @@ iOS (AEP 3.x)
 Resets current state of the AEP Edge extension and clears previously cached content related to current identity, if any.
 
 See [MobileCore.resetIdentities](../mobile-core/api-reference.md#resetidentities) for more details.
+
+## sendEvent
+
+Sends an Experience event to Adobe Experience Platform Edge Network.
+
+<TabsBlock orientation="horizontal" slots="heading, content" repeat="2"/>
+
+Android
+
+<Tabs query="platform=android&api=send-event"/>
+
+iOS (AEP 3.x)
+
+<Tabs query="platform=ios-aep&api=send-event"/>
+
+## setLocationHint
+
+Sets the Edge Network location hint used in requests to the Adobe Experience Platform Edge Network. Passing nil or an empty string clears the existing location hint. Edge Network responses may overwrite the location hint to a new value when necessary to manage network traffic.
+
+<InlineAlert variant="warning" slots="text"/>
+Use caution when setting the location hint. Only use location hints for the "EdgeNetwork" scope. An incorrect location hint value will cause all Edge Network requests to fail with 404 response code.
+
+<TabsBlock orientation="horizontal" slots="heading, content" repeat="2"/>
+
+Android
+
+<Tabs query="platform=android&api=set-location-hint"/>
+
+iOS (AEP 3.x)
+
+<Tabs query="platform=ios-aep&api=set-location-hint"/>
 
 ## Public classes
 

--- a/src/pages/documentation/edge-network-extensions/api-reference.md
+++ b/src/pages/documentation/edge-network-extensions/api-reference.md
@@ -69,6 +69,7 @@ iOS (AEP 3.x)
 Sets the Edge Network location hint used in requests to the Adobe Experience Platform Edge Network. Passing nil or an empty string clears the existing location hint. Edge Network responses may overwrite the location hint to a new value when necessary to manage network traffic.
 
 <InlineAlert variant="warning" slots="text"/>
+
 Use caution when setting the location hint. Only use location hints for the "EdgeNetwork" scope. An incorrect location hint value will cause all Edge Network requests to fail with 404 response code.
 
 <TabsBlock orientation="horizontal" slots="heading, content" repeat="2"/>

--- a/src/pages/documentation/edge-network-extensions/release-notes.md
+++ b/src/pages/documentation/edge-network-extensions/release-notes.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## October 19, 2022
+
+### iOS AEPEdge 1.5.0
+
+* Adds support for persisting the location hint returned by the Edge Network for the duration of the session for an improved user experience. Includes new APIs `getLocationHint` and `setLocationHint` allowing hybrid applications to share the location hint across SDKs.
+
+### Android Edge 1.4.0
+
+* Adds support for persisting the location hint returned by the Edge Network for the duration of the session for an improved user experience. Includes new APIs `getLocationHint` and `setLocationHint` allowing hybrid applications to share the location hint across SDKs.
+
 ## June 2, 2022
 
 ### iOS AEPEdge 1.4.1

--- a/src/pages/documentation/edge-network-extensions/tabs/api-reference.md
+++ b/src/pages/documentation/edge-network-extensions/tabs/api-reference.md
@@ -44,109 +44,6 @@ let extensionVersion = Edge.extensionVersion
 NSString *extensionVersion = [AEPMobileEdge extensionVersion];
 ```
 
-<Variant platform="android" api="send-event" repeat="8"/>
-
-#### Java
-
-**Syntax**
-
-```java
-public static void sendEvent(final ExperienceEvent experienceEvent, final EdgeCallback callback);
-```
-
-* _experienceEvent_ - the XDM [Experience Event](#experienceevent) to be sent to Adobe Experience Platform Edge Network
-* _completion_ - optional callback to be invoked when the request is complete, returning the associated [EdgeEventHandle(s)](#edgeeventhandle) received from the Adobe Experience Platform Edge Network. It may be invoked on a different thread.
-
-**Example**
-
-```java
-// create experience event from Map
-Map<String, Object> xdmData = new HashMap<>();
-xdmData.put("eventType", "SampleXDMEvent");
-xdmData.put("sample", "data");
-		
-ExperienceEvent experienceEvent = new ExperienceEvent.Builder()
-	.setXdmSchema(xdmData)
-	.build();
-```
-
-```java
-// example 1 - send the experience event without handling the Edge Network response
-Edge.sendEvent(experienceEvent, null);
-```
-
-```java
-// example 2 - send the experience event and handle the Edge Network response onComplete
-Edge.sendEvent(experienceEvent, new EdgeCallback() {
-  @Override
-  public void onComplete(final List<EdgeEventHandle> handles) {
-        // handle the Edge Network response 
-  }
-});
-```
-
-<Variant platform="ios-aep" api="send-event" repeat="15"/>
-
-#### Swift
-
-**Syntax**
-
-```swift
-static func sendEvent(experienceEvent: ExperienceEvent, _ completion: (([EdgeEventHandle]) -> Void)? = nil)
-```
-
-* _experienceEvent_ - the XDM [Experience Event](#experienceevent) to be sent to Adobe Experience Platform Edge Network
-* _completion_ - optional callback to be invoked when the request is complete, returning the associated [EdgeEventHandle(s)](#edgeeventhandle) received from the Adobe Experience Platform Edge Network. It may be invoked on a different thread.
-
-**Example**
-
-```swift
-//create experience event from dictionary:
-var xdmData : [String: Any] = ["eventType" : "SampleXDMEvent",
-                              "sample": "data"]
-let experienceEvent = ExperienceEvent(xdm: xdmData)
-```
-
-```swift
-// example 1 - send the experience event without handling the Edge Network response
-Edge.sendEvent(experienceEvent: experienceEvent)
-```
-
-```swift
-// example 2 - send the experience event and handle the Edge Network response onComplete
-Edge.sendEvent(experienceEvent: experienceEvent) { (handles: [EdgeEventHandle]) in
-            // handle the Edge Network response
-        }
-```
-
-#### Objective-C
-
-**Syntax**
-
-```objectivec
-+ (void) sendExperienceEvent:(AEPExperienceEvent * _Nonnull) completion:^(NSArray<AEPEdgeEventHandle *> * _Nonnull)completion
-```
-
-**Example**
-
-```objectivec
-//create experience event from dictionary:
-NSDictionary *xdmData = @{ @"eventType" : @"SampleXDMEvent"};
-NSDictionary *data = @{ @"sample" : @"data"};
-```
-
-```objectivec
-// example 1 - send the experience event without handling the Edge Network response
-[AEPMobileEdge sendExperienceEvent:event completion:nil];
-```
-
-```objectivec
-// example 2 - send the experience event and handle the Edge Network response onComplete
-[AEPMobileEdge sendExperienceEvent:event completion:^(NSArray<AEPEdgeEventHandle *> * _Nonnull handles) {
-  // handle the Edge Network response
-}];
-```
-
 <Variant platform="android" api="get-location-hint" repeat="6"/>
 
 #### Java
@@ -271,6 +168,109 @@ Use the AEPMobileCore API to register the Edge extension.
 
 [AEPMobileCore registerExtensions:@[AEPMobileEdge.class] completion:nil];...
 
+```
+
+<Variant platform="android" api="send-event" repeat="8"/>
+
+#### Java
+
+**Syntax**
+
+```java
+public static void sendEvent(final ExperienceEvent experienceEvent, final EdgeCallback callback);
+```
+
+* _experienceEvent_ - the XDM [Experience Event](#experienceevent) to be sent to Adobe Experience Platform Edge Network
+* _completion_ - optional callback to be invoked when the request is complete, returning the associated [EdgeEventHandle(s)](#edgeeventhandle) received from the Adobe Experience Platform Edge Network. It may be invoked on a different thread.
+
+**Example**
+
+```java
+// create experience event from Map
+Map<String, Object> xdmData = new HashMap<>();
+xdmData.put("eventType", "SampleXDMEvent");
+xdmData.put("sample", "data");
+    
+ExperienceEvent experienceEvent = new ExperienceEvent.Builder()
+  .setXdmSchema(xdmData)
+  .build();
+```
+
+```java
+// example 1 - send the experience event without handling the Edge Network response
+Edge.sendEvent(experienceEvent, null);
+```
+
+```java
+// example 2 - send the experience event and handle the Edge Network response onComplete
+Edge.sendEvent(experienceEvent, new EdgeCallback() {
+  @Override
+  public void onComplete(final List<EdgeEventHandle> handles) {
+        // handle the Edge Network response 
+  }
+});
+```
+
+<Variant platform="ios-aep" api="send-event" repeat="15"/>
+
+#### Swift
+
+**Syntax**
+
+```swift
+static func sendEvent(experienceEvent: ExperienceEvent, _ completion: (([EdgeEventHandle]) -> Void)? = nil)
+```
+
+* _experienceEvent_ - the XDM [Experience Event](#experienceevent) to be sent to Adobe Experience Platform Edge Network
+* _completion_ - optional callback to be invoked when the request is complete, returning the associated [EdgeEventHandle(s)](#edgeeventhandle) received from the Adobe Experience Platform Edge Network. It may be invoked on a different thread.
+
+**Example**
+
+```swift
+//create experience event from dictionary:
+var xdmData : [String: Any] = ["eventType" : "SampleXDMEvent",
+                              "sample": "data"]
+let experienceEvent = ExperienceEvent(xdm: xdmData)
+```
+
+```swift
+// example 1 - send the experience event without handling the Edge Network response
+Edge.sendEvent(experienceEvent: experienceEvent)
+```
+
+```swift
+// example 2 - send the experience event and handle the Edge Network response onComplete
+Edge.sendEvent(experienceEvent: experienceEvent) { (handles: [EdgeEventHandle]) in
+            // handle the Edge Network response
+        }
+```
+
+#### Objective-C
+
+**Syntax**
+
+```objectivec
++ (void) sendExperienceEvent:(AEPExperienceEvent * _Nonnull) completion:^(NSArray<AEPEdgeEventHandle *> * _Nonnull)completion
+```
+
+**Example**
+
+```objectivec
+//create experience event from dictionary:
+NSDictionary *xdmData = @{ @"eventType" : @"SampleXDMEvent"};
+NSDictionary *data = @{ @"sample" : @"data"};
+```
+
+```objectivec
+// example 1 - send the experience event without handling the Edge Network response
+[AEPMobileEdge sendExperienceEvent:event completion:nil];
+```
+
+```objectivec
+// example 2 - send the experience event and handle the Edge Network response onComplete
+[AEPMobileEdge sendExperienceEvent:event completion:^(NSArray<AEPEdgeEventHandle *> * _Nonnull handles) {
+  // handle the Edge Network response
+}];
 ```
 
 <Variant platform="android" api="set-location-hint" repeat="6"/>

--- a/src/pages/documentation/edge-network-extensions/tabs/api-reference.md
+++ b/src/pages/documentation/edge-network-extensions/tabs/api-reference.md
@@ -147,6 +147,72 @@ NSDictionary *data = @{ @"sample" : @"data"};
 }];
 ```
 
+<Variant platform="android" api="get-location-hint" repeat="6"/>
+
+#### Java
+
+**Syntax**
+
+```java
+public static void getLocationHint(final AdobeCallback<String> callback)
+```
+* _callback_ is invoked with the location hint. The location hint value may be null if the location hint expired or was not set. The callback may be invoked on a different thread. If `AdobeCallbackWithError` is provided, the default timeout is 1000ms and the `fail` method is called if the operation times out or an unexpected error occurs.
+
+**Example**
+
+```java
+Edge.getLocationHint(new AdobeCallbackWithError<String>() {
+    @Override
+    public void call(final String hint) {
+        // handle the hint here
+    }
+
+    @Override
+    public void fail(AdobeError adobeError) {
+        // handle error here
+    }
+});
+```
+
+<Variant platform="ios-aep" api="get-location-hint" repeat="11"/>
+
+#### Swift
+
+**Syntax**
+
+```swift
+static func getLocationHint(completion: @escaping (String?, Error?) -> Void)
+```
+* _completion_ is invoked with the location hint, or an `AEPError` if the request times out or an unexpected error occurs. The location hint value may be nil if the location hint expired or was not set. The default timeout is 1000ms. The completion handler may be invoked on a different thread.
+
+**Example**
+
+```swift
+Edge.getLocationHint { (hint, error) in
+  if let error = error {
+    // handle error here
+  } else {
+    // handle location hint here
+  }
+}
+```
+
+#### Objective-C
+
+**Syntax**
+
+```objectivec
++ (void) getLocationHint:^(NSString * _Nullable hint, NSError * _Nullable error)completion
+```
+
+**Example**
+
+```objectivec
+[AEPMobileEdge getLocationHint:^(NSString *hint, NSError *error) {   
+    // handle the error and the hint here
+}];
+```
+
 <Variant platform="android" api="register-extension" repeat="5"/>
 
 #### Java
@@ -205,6 +271,55 @@ Use the AEPMobileCore API to register the Edge extension.
 
 [AEPMobileCore registerExtensions:@[AEPMobileEdge.class] completion:nil];...
 
+```
+
+<Variant platform="android" api="set-location-hint" repeat="6"/>
+
+#### Java
+
+**Syntax**
+
+```java
+public static void setLocationHint(final String hint)
+```
+- _hint_ the Edge Network location hint to use when connecting to the Adobe Experience Platform Edge Network.
+
+**Example**
+
+```java
+Edge.setLocationHint(hint);
+```
+
+<Variant platform="ios-aep" api="set-location-hint" repeat="11"/>
+
+#### Swift
+
+**Syntax**
+
+```swift
+@objc(setLocationHint:)
+public static func setLocationHint(_ hint: String?)
+```
+- _hint_ the Edge Network location hint to use when connecting to the Adobe Experience Platform Edge Network.
+
+**Example**
+
+```swift
+Edge.setLocationHint(hint)
+```
+
+#### Objective-C
+
+**Syntax**
+
+```objectivec
++ (void) setLocationHint: (NSString * _Nullable hint);
+```
+
+**Example**
+
+```objectivec
+[AEPMobileEdge setLocationHint:hint];
 ```
 
 <Variant platform="android" api="xdm-schema" repeat="5"/>

--- a/src/pages/documentation/release-notes/index.md
+++ b/src/pages/documentation/release-notes/index.md
@@ -4,6 +4,16 @@ description: Release notes and change logs for the Adobe Experience Platform Mob
 
 # Release notes
 
+## October 19, 2022
+
+### iOS AEPEdge 1.5.0
+
+* Adds support for persisting the location hint returned by the Edge Network for the duration of the session for an improved user experience. Includes new APIs `getLocationHint` and `setLocationHint` allowing hybrid applications to share the location hint across SDKs.
+
+### Android Edge 1.4.0
+
+* Adds support for persisting the location hint returned by the Edge Network for the duration of the session for an improved user experience. Includes new APIs `getLocationHint` and `setLocationHint` allowing hybrid applications to share the location hint across SDKs.
+
 ## October 11, 2022
 
 ### iOS AEPPlaces 3.0.2


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add API references for Edge.getLocationHint and Edge.setLocationHint.
Add release notes for iOS Edge v1.5.0 and Android Edge v1.4.0

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
