### PR TITLE
Fix incorrect syntax for ACP trackaction in swift

### DIFF
--- a/src/pages/documentation/mobile-core/tabs/api-reference.md
+++ b/src/pages/documentation/mobile-core/tabs/api-reference.md
@@ -1655,9 +1655,8 @@ MobileCore.trackAction("loginClicked", additionalContextData);
 
 **Syntax**
 
-```swift
-@objc(trackAction:data:)
-static func track(action: String?, data: [String: Any]?)
+```objc
++ (void) trackAction: (nullable NSString*) action data: (nullable NSDictionary*) contextData;
 ```
 
 * _action_ contains the name of the action to track.
@@ -1666,7 +1665,7 @@ static func track(action: String?, data: [String: Any]?)
 **Example**
 
 ```swift
-ACPCore.track(action: "action name", data: ["key": "value"])
+ACPCore.trackAction("action name", data: ["key": "value"])
 ```
 
 #### Objective-C


### PR DESCRIPTION
A customer pointed out that we had two different syntaxes for our TrackAction api here: https://developer.adobe.com/client-sdks/documentation/mobile-core/api-reference/#swift-21 and here: https://developer.adobe.com/client-sdks/documentation/getting-started/track-events/#swift-3. The latter is the correct one. So i have updated the api ref to be correct.