### PR TITLE
Add docs for registerExtensions() and cleanup Signal

### DIFF
--- a/src/pages/documentation/mobile-core/api-reference.md
+++ b/src/pages/documentation/mobile-core/api-reference.md
@@ -117,15 +117,16 @@ iOS
 
 <Tabs query="platform=react-native&api=log"/> --->
 
-## registerExtension(s)
+## registerExtensions
 
 Extensions are registered with Mobile Core so that they can dispatch and listen for events.
+This API can be used to register desired extensions and boot up the SDK for event processing. Calling `MobileCore.start()` API is no longer required when using `MobileCore.registerExtensions()`.
 
 <InlineAlert variant="warning" slots="text"/>
 
 Extension registration is **mandatory**. Attempting to make extension-specific API calls without registering the extension will lead to undefined behavior.
 
-The following code snippets demonstrate how you can import and register the Mobile Core and Profile extensions. You can also see, for reference, how Identity, Lifecycle, Signal, Profile, and other extensions are imported and registered.
+The following code snippets demonstrate how Lifecycle, Signal, Profile, Edge and other extensions are imported and registered.
 
 <TabsBlock orientation="horizontal" slots="heading, content" repeat="2"/>
 

--- a/src/pages/documentation/mobile-core/api-reference.md
+++ b/src/pages/documentation/mobile-core/api-reference.md
@@ -126,17 +126,17 @@ This API can be used to register desired extensions and boot up the SDK for even
 
 Extension registration is **mandatory**. Attempting to make extension-specific API calls without registering the extension will lead to undefined behavior.
 
-The following code snippets demonstrate how Lifecycle, Signal, Profile, Edge and other extensions are imported and registered.
+The following code snippets demonstrate how Lifecycle, Signal, Profile, Edge, and other extensions are imported and registered.
 
 <TabsBlock orientation="horizontal" slots="heading, content" repeat="2"/>
 
 Android
 
-<Tabs query="platform=android&api=register-extension"/>
+<Tabs query="platform=android&api=register-extensions"/>
 
 iOS
 
-<Tabs query="platform=ios&api=register-extension"/>
+<Tabs query="platform=ios&api=register-extensions"/>
 
 <!--- React Native
 

--- a/src/pages/documentation/mobile-core/api-reference.md
+++ b/src/pages/documentation/mobile-core/api-reference.md
@@ -120,7 +120,7 @@ iOS
 ## registerExtensions
 
 Extensions are registered with Mobile Core so that they can dispatch and listen for events.
-This API can be used to register desired extensions and boot up the SDK for event processing. Calling `MobileCore.start()` API is no longer required when using `MobileCore.registerExtensions()`.
+This API can be used to register desired extensions and boot up the SDK for event processing. Calling `MobileCore.start()` API is deprecated starting Mobile Core v2.0.0 and is no longer required when using `MobileCore.registerExtensions()`.
 
 <InlineAlert variant="warning" slots="text"/>
 

--- a/src/pages/documentation/mobile-core/signal/api-reference.md
+++ b/src/pages/documentation/mobile-core/signal/api-reference.md
@@ -29,7 +29,7 @@ Flutter
 ## registerExtension
 <InlineAlert variant="warning" slots="text"/>
 
-This API is only available in Android and is deprecated in the latest version of the Signal extension. Use [`MobileCore.registerExtensions()`](../api-reference.md#registerextensions) instead.
+This API is only available in Android and is deprecated starting version 2.0.0 of the Signal extension. Use [`MobileCore.registerExtensions()`](../api-reference.md#registerextensions) instead.
 
 Registers the Signal extension with the Mobile Core.
 

--- a/src/pages/documentation/mobile-core/signal/api-reference.md
+++ b/src/pages/documentation/mobile-core/signal/api-reference.md
@@ -27,18 +27,17 @@ Flutter
 <Tabs query="platform=flutter&api=extension-version"/> --->
 
 ## registerExtension
+<InlineAlert variant="warning" slots="text"/>
+
+This API is only available in Android and is deprecated in the latest version of the Signal extension. Use [`MobileCore.registerExtensions()`](../api-reference.md#registerextensions) instead.
 
 Registers the Signal extension with the Mobile Core.
 
-<TabsBlock orientation="horizontal" slots="heading, content" repeat="2"/>
+<TabsBlock orientation="horizontal" slots="heading, content" repeat="1"/>
 
 Android
 
 <Tabs query="platform=android&api=register-extension"/>
-
-iOS
-
-<Tabs query="platform=ios&api=register-extension"/>
 
 <!--- React Native
 

--- a/src/pages/documentation/mobile-core/signal/api-reference.md
+++ b/src/pages/documentation/mobile-core/signal/api-reference.md
@@ -29,7 +29,7 @@ Flutter
 ## registerExtension
 <InlineAlert variant="warning" slots="text"/>
 
-This API is only available in Android and is deprecated starting version 2.0.0 of the Signal extension. Use [`MobileCore.registerExtensions()`](../api-reference.md#registerextensions) instead.
+This API is only available in Android and is deprecated starting version 2.0.0 of the Signal extension. Use [`MobileCore.registerExtensions()`](../../api-reference.md#registerextensions) instead.
 
 Registers the Signal extension with the Mobile Core.
 
@@ -45,5 +45,5 @@ Android
 
 ## collectPII
 
-The Signal extension can be used to handle `collectPII` rules. For more information, see the [collectPII](../api-reference.md#collectpii) API.
+The Signal extension can be used to handle `collectPII` rules. For more information, see the [collectPII](../../api-reference.md#collectpii) API.
 

--- a/src/pages/documentation/mobile-core/signal/index.md
+++ b/src/pages/documentation/mobile-core/signal/index.md
@@ -24,6 +24,10 @@ For more information about creating and configuring a rule in the Data Collectio
 
 ## Add the Signal extension to your app
 
+<InlineAlert variant="warning" slots="text"/>
+
+Using dynamic dependency versions is not recommended for production apps. Refer to this [page](../../manage-gradle-dependencies.md) for managing gradle dependencies.
+
 <TabsBlock orientation="horizontal" slots="heading, content" repeat="2"/>
 
 Android

--- a/src/pages/documentation/mobile-core/signal/index.md
+++ b/src/pages/documentation/mobile-core/signal/index.md
@@ -4,7 +4,7 @@ import Tabs from './tabs/index.md'
 
 The Signal extension allows marketers to send a "signal" to their apps through the Adobe Experience Platform Mobile SDKs. This signal might tell the Mobile SDKs or the apps to complete tasks, such as send PII-labeled data, to trigger a postback to a third-party ad-network and open an app deep link or URL. To ensure that signals are sent or are activated, the marketers need to configure triggers and traits in the Data Collection UI.
 
-The Signal extension is bundled with the [MobileCore (Android)/ACPCore (iOS)](../index.md) extension and allows you to send postbacks to third-party endpoints and open URLs, such as web URLs or application deep links, when using rules actions in the Data Collection UI.
+The Signal extension allows you to send postbacks to third-party endpoints and open URLs, such as web URLs or application deep links, when using rules actions in the Data Collection UI.
 
 To send PII data to external destinations, the `PII` action can trigger the Rules Engine when certain triggers and traits match. When setting a rule, you can also set the `PII` action for a Signal event. The `collectPii` API can then be used to trigger the rule and send the PII data to a remote server.
 
@@ -44,9 +44,9 @@ Flutter
 
 ## Register the Signal extension
 
-The `registerExtension()` API registers the Signal extension with the Mobile Core extension. This API allows the extension to send and receive events to and from the Mobile SDK.
+The `MobileCore.registerExtensions()` API can be used to register the Signal extension with the Mobile Core extension. This API allows the extension to send and receive events to and from the Mobile SDK.
 
-To register the Identity extension, use the following code sample:
+To register the Signal extension, use the following code sample:
 
 <TabsBlock orientation="horizontal" slots="heading, content" repeat="2"/>
 

--- a/src/pages/documentation/mobile-core/signal/tabs/api-reference.md
+++ b/src/pages/documentation/mobile-core/signal/tabs/api-reference.md
@@ -68,10 +68,6 @@ public static void registerExtension()
 Signal.registerExtension();
 ```
 
-<Variant platform="ios" api="register-extension" repeat="1"/>
-
-This API no longer exists in `Signal`. Instead, the extension should be registered by calling the `registerExtensions` API in the MobileCore. Please see the updated SDK initialization steps at the [migrate to Swift tutorial.](../../migrate-to-swift.md#update-sdk-initialization)
-
 <!--- <Variant platform="react-native" api="register-extension" repeat="1"/>
 
 When using React Native, register the Signal extension with Mobile Core in native code as shown on the Android and iOS tabs. --->

--- a/src/pages/documentation/mobile-core/signal/tabs/api-reference.md
+++ b/src/pages/documentation/mobile-core/signal/tabs/api-reference.md
@@ -5,6 +5,7 @@
 **Syntax**
 
 ```java
+@NonNull
 public static String extensionVersion();
 ```
 

--- a/src/pages/documentation/mobile-core/signal/tabs/index.md
+++ b/src/pages/documentation/mobile-core/signal/tabs/index.md
@@ -5,13 +5,13 @@
 Add the [Mobile Core](../index.md) extension to your project using the app's Gradle file.
 
 ```java
-implementation 'com.adobe.marketing.mobile:sdk-core:1.+'
+implementation 'com.adobe.marketing.mobile:sdk-core:2.+'
 ```
 
 Import the Signal extension in your application's main activity.
 
 ```java
-import com.adobe.marketing.mobile.*;
+import com.adobe.marketing.mobile.Signal;
 ```
 
 <Variant platform="ios" task="add" repeat="8"/>
@@ -61,11 +61,11 @@ Importing the Signal extension:
 import 'package:flutter_acpcore/flutter_acpsignal.dart';
 ``` --->
 
-<Variant platform="android" task="register" repeat="4"/>
+<Variant platform="android" task="register" repeat="3"/>
+
+After calling the `setApplication()` method in the `onCreate()` method, register the Signal extension.
 
 #### Java
-
-After calling the `setApplication()` method in the `onCreate()` method, register the Signal extension. If the registration was not successful, an `InvalidInitException` is thrown.
 
 ```java
 public class MobileApp extends Application {
@@ -74,23 +74,14 @@ public class MobileApp extends Application {
     public void onCreate() {
         super.onCreate();
         MobileCore.setApplication(this);
-        try {
-            Signal.registerExtension();
-            // register other extensions
-            MobileCore.start(new AdobeCallback () {
-                @Override
-                public void call(Object o) {
-                    MobileCore.configureWithAppID("yourAppId");
-                }
-            });    
-        } catch (Exception e) {
-            //Log the exception
-         }
+
+        List<Class<? extends Extension>> extensions = Arrays.asList(Signal.EXTENSION, ...);
+        MobileCore.registerExtensions(extensions, o -> {
+            // Any other post registration processing
+        });
     }
 }
 ```
-
-Please note that the Signal extension is automatically included in the Mobile Core extension by Maven. When you manually install the Signal extension, ensure that you add the `signal-1.x.x.aar` library to your project.
 
 <Variant platform="ios" task="register" repeat="5"/>
 

--- a/src/pages/documentation/mobile-core/signal/tabs/index.md
+++ b/src/pages/documentation/mobile-core/signal/tabs/index.md
@@ -2,15 +2,18 @@
 
 #### Java
 
-Add the [Mobile Core](../index.md) extension to your project using the app's Gradle file.
+Add the Signal extension and it's dependency, the [Mobile Core](../index.md) extension to your project using the app's Gradle file.
 
 ```java
-implementation 'com.adobe.marketing.mobile:sdk-core:2.+'
+implementation 'com.adobe.marketing.mobile:core:2.+'
+implementation 'com.adobe.marketing.mobile:signal:2.+'
 ```
 
-Import the Signal extension in your application's main activity.
+Import the Signal and MobileCore extensions in your application's main activity.
+
 
 ```java
+import com.adobe.marketing.mobile.MobileCore;
 import com.adobe.marketing.mobile.Signal;
 ```
 

--- a/src/pages/documentation/mobile-core/tabs/api-reference.md
+++ b/src/pages/documentation/mobile-core/tabs/api-reference.md
@@ -390,7 +390,7 @@ const DEBUG = "ACP_LOG_LEVEL_DEBUG";
 const VERBOSE = "ACP_LOG_LEVEL_VERBOSE";
 ``` --->
 
-<Variant platform="android" api="register-extension" repeat="3"/>
+<Variant platform="android" api="register-extensions" repeat="3"/>
 
 #### Java
 
@@ -410,14 +410,14 @@ import com.adobe.marketing.mobile.UserProfile;
 import android.app.Application;
 ...
 public class MainApp extends Application {
-    private static final String APP_ID = "YOUR_APP_ID";
+    private static final String ENVIRONMENT_FILE_ID = "YOUR_ENVIRONMENT_FILE_ID";
 
     @Override
     public void onCreate() {
         super.onCreate();
 
         MobileCore.setApplication(this);
-        MobileCore.configureWithAppID(APP_ID);
+        MobileCore.configureWithAppID(ENVIRONMENT_FILE_ID);
 
         List<Class<? extends Extension>> extensions = Arrays.asList(
                 Lifecycle.EXTENSION,
@@ -433,7 +433,7 @@ public class MainApp extends Application {
 }
 ```
 
-<Variant platform="ios" api="register-extension" repeat="6"/>
+<Variant platform="ios" api="register-extensions" repeat="6"/>
 
 #### Swift
 

--- a/src/pages/documentation/mobile-core/tabs/api-reference.md
+++ b/src/pages/documentation/mobile-core/tabs/api-reference.md
@@ -390,9 +390,7 @@ const DEBUG = "ACP_LOG_LEVEL_DEBUG";
 const VERBOSE = "ACP_LOG_LEVEL_VERBOSE";
 ``` --->
 
-<Variant platform="android" api="register-extension" repeat="4"/>
-
-After you register the extensions, call the `start` API in Mobile Core to initialize the SDK as shown below. This step is required to boot up the SDK for event processing. The following code snippet is provided as a sample reference.
+<Variant platform="android" api="register-extension" repeat="3"/>
 
 #### Java
 
@@ -400,8 +398,9 @@ After you register the extensions, call the `start` API in Mobile Core to initia
 
 ```java
 import com.adobe.marketing.mobile.AdobeCallback;
-import com.adobe.marketing.mobile.Identity;
-import com.adobe.marketing.mobile.InvalidInitException;
+import com.adobe.marketing.mobile.Edge;
+import com.adobe.marketing.mobile.edge.consent.Consent;
+import com.adobe.marketing.mobile.edge.identity.Identity;
 import com.adobe.marketing.mobile.Lifecycle;
 import com.adobe.marketing.mobile.LoggingMode;
 import com.adobe.marketing.mobile.MobileCore;
@@ -411,34 +410,30 @@ import com.adobe.marketing.mobile.UserProfile;
 import android.app.Application;
 ...
 public class MainApp extends Application {
-  ...
-  @Override
-  public void on Create(){
-    super.onCreate();
-    MobileCore.setApplication(this);
-        MobileCore.setLogLevel(LoggingMode.DEBUG);
-    ...
-    try {
-      UserProfile.registerExtension();
-            Identity.registerExtension();
-            Lifecycle.registerExtension();
-            Signal.registerExtension();
-            MobileCore.start(new AdobeCallback () {
-            @Override
-            public void call(Object o) {
-            MobileCore.configureWithAppID("<your_environment_id_from_Launch>");
+    private static final String APP_ID = "YOUR_APP_ID";
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+
+        MobileCore.setApplication(this);
+        MobileCore.configureWithAppID(APP_ID);
+
+        List<Class<? extends Extension>> extensions = Arrays.asList(
+                Lifecycle.EXTENSION,
+                Signal.EXTENSION,
+                UserProfile.EXTENSION
+                Edge.EXTENSION,
+                Consent.EXTENSION,
+                EdgeIdentity.EXTENSION);
+        MobileCore.registerExtensions(extensions, o -> {
+            Log.d(LOG_TAG, "AEP Mobile SDK is initialized");
+        });
     }
-});
-    } catch (InvalidInitException e) {
-      ...
-    }
-  }
 }
 ```
 
-<Variant platform="ios" api="register-extension" repeat="7"/>
-
-For iOS Swift libraries, registration is changed to a single API call (as shown in the snippets below). Calling the `MobileCore.start` API is no longer required.
+<Variant platform="ios" api="register-extension" repeat="6"/>
 
 #### Swift
 
@@ -447,7 +442,7 @@ For iOS Swift libraries, registration is changed to a single API call (as shown 
 ```swift
 // AppDelegate.swift
 func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-    MobileCore.registerExtensions([Signal.self, Lifecycle.self, UserProfile.self, Edge.self, AEPEdgeIdentity.Identity.self, Consent.self, AEPIdentity.Identity.self, Analytics.self], {
+    MobileCore.registerExtensions([Signal.self, Lifecycle.self, UserProfile.self, Edge.self, AEPEdgeIdentity.Identity.self, Consent.self], {
         MobileCore.configureWith(appId: "yourAppId")
     })
   ...
@@ -461,7 +456,7 @@ func application(_ application: UIApplication, didFinishLaunchingWithOptions lau
 ```objectivec
 // AppDelegate.m
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-    [AEPMobileCore registerExtensions:@[AEPMobileSignal.class, AEPMobileLifecycle.class, AEPMobileUserProfile.class, AEPMobileEdge.class, AEPMobileEdgeIdentity.class, AEPMobileEdgeConsent.class, AEPMobileIdentity.class, AEPMobileAnalytics.class] completion:^{
+    [AEPMobileCore registerExtensions:@[AEPMobileSignal.class, AEPMobileLifecycle.class, AEPMobileUserProfile.class, AEPMobileEdge.class, AEPMobileEdgeIdentity.class, AEPMobileEdgeConsent.class] completion:^{
     [AEPMobileCore configureWithAppId: @"yourAppId"];
   }];
   ...
@@ -554,11 +549,9 @@ For Flutter apps, initialize the SDK using native code in your `AppDelegate` and
 
 The initialization code is located in the [Flutter ACPCore Github README](https://github.com/adobe/flutter_acpcore). --->
 
-<Variant platform="android" api="reset-identities" repeat="6"/>
+<Variant platform="android" api="reset-identities" repeat="5"/>
 
 #### Java
-
-This method is only available in Mobile Core v.1.8.0 and above.
 
 **Syntax**
 
@@ -653,7 +646,12 @@ public class CoreApp extends Application {
    public void onCreate() {
       super.onCreate();
       MobileCore.setApplication(this);
-      MobileCore.start(null);
+
+      List<Class<? extends Extension>> extensions = Arrays.asList(
+                Lifecycle.EXTENSION, Signal.EXTENSION, UserProfile.EXTENSION...);
+      MobileCore.registerExtensions(extensions, o -> {
+          Log.d(LOG_TAG, "AEP Mobile SDK is initialized");
+      });
    }
 }
 ```

--- a/src/pages/documentation/mobile-core/tabs/api-reference.md
+++ b/src/pages/documentation/mobile-core/tabs/api-reference.md
@@ -390,9 +390,15 @@ const DEBUG = "ACP_LOG_LEVEL_DEBUG";
 const VERBOSE = "ACP_LOG_LEVEL_VERBOSE";
 ``` --->
 
-<Variant platform="android" api="register-extensions" repeat="3"/>
+<Variant platform="android" api="register-extensions" repeat="5"/>
 
 #### Java
+
+**Syntax**
+
+```java
+public static void registerExtensions(@NonNull final List<Class<? extends Extension>> extensions, @Nullable final AdobeCallback<?> completionCallback)
+```
 
 **Example**
 
@@ -433,9 +439,15 @@ public class MainApp extends Application {
 }
 ```
 
-<Variant platform="ios" api="register-extensions" repeat="6"/>
+<Variant platform="ios" api="register-extensions" repeat="8"/>
 
 #### Swift
+
+**Syntax**
+
+```swift
+public static func registerExtensions(_ extensions: [NSObject.Type], _ completion: (() -> Void)? = nil)
+```
 
 **Example**
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
```
- Mobile Core
  - Document MobileCore.registerExtensions() API

- Signal
  - Remove 1.x and ACP references
  - Deprecation notice for registerExtension() and remove iOS tab
  - Use 2.0 example for registration in Overview

 ```

<!--- Describe your changes in detail -->

## Related Issue
N/A
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
MobileCore.registerExtensions() is the recommended way of registering extensions for the latest version. The docs in the latest version should be modified to reflect the api. 
Use Signal as an example to demonstrate changes to be done for individual extensions.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- Run yarn dev and verify that the changes reflect as desired.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
