### PR TITLE
Add Adobe standard 2.0 info in the Consent doc

### DIFF
--- a/src/@adobe/gatsby-theme-aio/components/InlineAlert/index.js
+++ b/src/@adobe/gatsby-theme-aio/components/InlineAlert/index.js
@@ -16,6 +16,12 @@ import * as Icons from '@adobe/gatsby-theme-aio/src/components/Icons';
 import PropTypes from 'prop-types';
 import '@spectrum-css/inlinealert';
 
+const commonCss = css`
+  font-size: 1rem;
+  line-height: 1.3rem;
+  padding-right: 30px;
+`;
+
 const getIconName = (variant) => {
   let icon = variant;
 
@@ -26,10 +32,33 @@ const getIconName = (variant) => {
   return `${icon.charAt(0).toUpperCase()}${icon.slice(1)}Medium`;
 };
 
-const InlineAlert = ({ variant = 'info', header, text }) => {
-  const Icon = Icons[getIconName(variant)];
+  const InlineAlertTexts = ({ texts }) => {
+    const textKeys = Object.keys(texts).filter((key) => key.startsWith('text'));
+    return textKeys.map((textKey, index) =>
+      index === 0
+        ? cloneElement(texts[textKey], {
+            className: 'spectrum-InLineAlert-content',
+            css: css`
+              margin-top: 0;
+              margin-left: var(--spectrum-global-dimension-size-300) !important;
+              ${commonCss};
+            `
+          })
+        : cloneElement(texts[textKey], {
+            className: 'spectrum-InLineAlert-content',
+            css: css`
+              margin-top: var(--spectrum-global-dimension-size-150);
+              margin-left: var(--spectrum-global-dimension-size-300) !important;
+              ${commonCss};
+            `
+          })
+    );
+  };
 
-  if (header){
+  const InlineAlert = ({ variant = 'info', header, ...props }) => {
+    const Icon = Icons[getIconName(variant)] ? Icons[getIconName(variant)] : Icons.NeutralMedium;
+    variant = variant === 'warning' ? 'negative' : variant;
+  
     return (
         <div
           role="alert"
@@ -44,82 +73,29 @@ const InlineAlert = ({ variant = 'info', header, text }) => {
                 margin-left: var(--spectrum-global-dimension-size-175) !important;
             }
           `}>
-          <Icon className="spectrum-InLineAlert-icon" />
-          <div
-            className="spectrum-InLineAlert-header"
-            css={css`
+        <Icon 
+        className="spectrum-Icon spectrum-Icon--sizeM spectrum-InLineAlert-icon"
+        css={css`
+        display: inline-block !important;
+        `} />
+        <div>
+          {header &&
+            cloneElement(header, {
+              className: 'spectrum-InLineAlert-header',
+              css: css`
                 margin-top: 0;
-                margin-bottom: var(--spectrum-global-dimension-size-300);
                 margin-left: var(--spectrum-global-dimension-size-300);
-                p {
-                    font-size: larger;
-                }
-            `}>
-                {cloneElement(header, {
-                    className: ' ',
-                    css: css`
-                        margin: 0 !important;
-                    `
-                })}
-            </div>
-          <div
-            className="spectrum-InLineAlert-content"
-            css={css`
-              margin-top: 0;
-              margin-left: var(--spectrum-global-dimension-size-300);
-              
-              p {
-                margin: 0;
-              }
-            `}>
-            {cloneElement(text, {
-              className: ' ',
-              css: css`
-                margin: 0 !important;
+                margin-bottom: 0.5rem;
+                font-size: 1rem;
+                line-height: 1.3rem;
               `
             })}
-          </div>
         </div>
-      ); 
-  }
-  else {
-    return (
-        <div
-          role="alert"
-          className={`spectrum-InLineAlert spectrum-InLineAlert--${variant}`}
-          css={css`
-            display: block !important;
-            min-width: 0 !important;
-            width: 100%;
-            margin-top: var(--spectrum-global-dimension-size-300);
-            svg {
-                left: 0;
-                margin-left: var(--spectrum-global-dimension-size-175) !important;
-            }
-          `}>
-          <Icon className="spectrum-InLineAlert-icon" />
-          <div
-            className="spectrum-InLineAlert-content"
-            css={css`
-              margin-top: 0;
-              margin-left: var(--spectrum-global-dimension-size-300);
-              
-              p {
-                margin: 0;
-              }
-            `}>
-            {cloneElement(text, {
-              className: ' ',
-              css: css`
-                margin: 0 !important;
-              `
-            })}
-          </div>
-        </div>
-      );
-  }
+        <InlineAlertTexts texts={props} />
+      </div>
+    );
+  };
 
-};
 
 InlineAlert.propTypes = {
   variant: PropTypes.string,

--- a/src/pages/documentation/consent-for-edge-network/api-reference.md
+++ b/src/pages/documentation/consent-for-edge-network/api-reference.md
@@ -72,7 +72,7 @@ When `Consent.update` API is called, the Consent extension uses Adobe Standard 2
 The following example shows when `Consent.update` is called to set collect consent to `y`:
 
 ```swift
-// Example in iOS (Swift),  updating users collect consent to 'yes'
+// Example in iOS (Swift),  updating user's collect consent to 'yes'
 let collectConsent = ["collect": ["val": "y"]]
 let currentConsents = ["consents": collectConsent]
 Consent.update(with: currentConsents)

--- a/src/pages/documentation/consent-for-edge-network/api-reference.md
+++ b/src/pages/documentation/consent-for-edge-network/api-reference.md
@@ -65,4 +65,25 @@ iOS
 
 <Tabs query="platform=ios&api=update-consents"/>
 
+<InlineAlert variant="info" slots="text"/>
+
+The updateConsents API automatically includes the following properties in its request to Edge Network: `standard` with the value `Adobe` and `version` with the value `2.0`. Additionally, the property `metadata` is set to the time at which the API is called.
+
+In the following, you can see an example in a request that set collect consent to `y`:
+```json
+    "consent": [
+        {
+        "standard": "Adobe",
+        "version": "2.0",
+        "value": {
+            "metadata": {
+            "time": "xxxx-xx-xxxxx:xx:xx.xxxx"
+            },
+            "collect": {
+            "val": "y"
+            }
+          }
+        }
+     ]
+```
 For additional information about the management of consent preferences, please refer to the [Privacy and GDPR documentation](../resources/privacy-and-gdpr.md#using-experience-platform-sdks-for-edge-network).

--- a/src/pages/documentation/consent-for-edge-network/api-reference.md
+++ b/src/pages/documentation/consent-for-edge-network/api-reference.md
@@ -67,9 +67,20 @@ iOS
 
 <InlineAlert variant="info" slots="text"/>
 
-The updateConsents API automatically includes the following properties in its request to Edge Network: `standard` with the value `Adobe` and `version` with the value `2.0`. Additionally, the property `metadata` is set to the time at which the API is called.
+The Consent extension uses Adobe Standard 2.0 when communicating with the Edge Network, when the updateConsents API is called.  Additionally, the property `metadata` is set to the time at which the API is called.
 
-In the following, you can see an example in a request that set collect consent to `y`:
+Here is an example where updateConsents is called to set collect consent to y and bellow you can see the snippet of the request payload sent to the Edge Network.
+
+**Set and update Consent**
+
+```swift
+// Example in iOS (Swift),  updating users collect consent to 'yes'
+let collectConsent = ["collect": ["val": "y"]]
+let currentConsents = ["consents": collectConsent]
+Consent.update(with: currentConsents)
+```
+
+**Request payload sent to the Edge Network**
 
 ```json
     "consent": [
@@ -78,7 +89,7 @@ In the following, you can see an example in a request that set collect consent t
         "version": "2.0",
         "value": {
             "metadata": {
-            "time": "xxxx-xx-xxxxx:xx:xx.xxxx"
+            "time" : "2023-10-03T17:23:04.443Z"
             },
             "collect": {
             "val": "y"

--- a/src/pages/documentation/consent-for-edge-network/api-reference.md
+++ b/src/pages/documentation/consent-for-edge-network/api-reference.md
@@ -65,13 +65,11 @@ iOS
 
 <Tabs query="platform=ios&api=update-consents"/>
 
-<InlineAlert variant="info" slots="text"/>
+<InlineAlert variant="info" slots="text1, text2, text3, text4, text5"/>
 
-The Consent extension uses Adobe Standard 2.0 when communicating with the Edge Network, when the updateConsents API is called.  Additionally, the property `metadata` is set to the time at which the API is called.
+When `Consent.update` API is called, the Consent extension uses Adobe Standard 2.0 to communicate with the Edge Network.  Additionally, the property `metadata` is set to the time at which the API is called.
 
-Here is an example where updateConsents is called to set collect consent to y and bellow you can see the snippet of the request payload sent to the Edge Network.
-
-**Set and update Consent**
+Here is an example where `Consent.update` is called to set collect consent to y:
 
 ```swift
 // Example in iOS (Swift),  updating users collect consent to 'yes'
@@ -80,7 +78,7 @@ let currentConsents = ["consents": collectConsent]
 Consent.update(with: currentConsents)
 ```
 
-**Request payload sent to the Edge Network**
+Bellow you can see the snippet of the request payload sent to the Edge Network:
 
 ```json
     "consent": [

--- a/src/pages/documentation/consent-for-edge-network/api-reference.md
+++ b/src/pages/documentation/consent-for-edge-network/api-reference.md
@@ -69,7 +69,7 @@ iOS
 
 When `Consent.update` API is called, the Consent extension uses Adobe Standard 2.0 to communicate with the Edge Network.  Additionally, the property `metadata` is set to the time at which the API is called.
 
-Here is an example where `Consent.update` is called to set collect consent to y:
+The following example shows when `Consent.update` is called to set collect consent to `y`:
 
 ```swift
 // Example in iOS (Swift),  updating users collect consent to 'yes'

--- a/src/pages/documentation/consent-for-edge-network/api-reference.md
+++ b/src/pages/documentation/consent-for-edge-network/api-reference.md
@@ -70,6 +70,7 @@ iOS
 The updateConsents API automatically includes the following properties in its request to Edge Network: `standard` with the value `Adobe` and `version` with the value `2.0`. Additionally, the property `metadata` is set to the time at which the API is called.
 
 In the following, you can see an example in a request that set collect consent to `y`:
+
 ```json
     "consent": [
         {
@@ -86,4 +87,5 @@ In the following, you can see an example in a request that set collect consent t
         }
      ]
 ```
+
 For additional information about the management of consent preferences, please refer to the [Privacy and GDPR documentation](../resources/privacy-and-gdpr.md#using-experience-platform-sdks-for-edge-network).

--- a/src/pages/documentation/consent-for-edge-network/index.md
+++ b/src/pages/documentation/consent-for-edge-network/index.md
@@ -27,6 +27,10 @@ The Adobe Experience Platform Consent mobile extension enables consent preferenc
 
 In order to ingest and use the data collected by this extension, follow the guide on [ingesting data using the Consents and Preferences data type](https://experienceleague.adobe.com/docs/experience-platform/xdm/data-types/consents.html#ingest).
 
+<InlineAlert variant="info" slots="text"/>
+
+The Consent extension uses Adobe Standard 2.0 when communicating with the Edge Network.
+
 <InlineAlert variant="warning" slots="text"/>
 
 The use of this extension is currently limited to the setting (and enforcement) of client-side, macro consent flags. While SDK APIs allow for granular and global consent preference collection, flags are not consistently enforced with upstream applications and therefore will not accommodate use cases that rely on global/granular consent preferences.


### PR DESCRIPTION
Add Adobe uses standard 2.0 and metadata time info in the Consent doc.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
