### PR TITLE
Fix iOS Lifecycle metrics referencing ACP

### DIFF
--- a/src/pages/home/getting-started/tabs/enable-debug-logging.md
+++ b/src/pages/home/getting-started/tabs/enable-debug-logging.md
@@ -108,77 +108,134 @@ To ensure accurate session and crash reporting, this call must be added to every
 
 #### Swift
 
-Start Lifecycle data collection by calling `lifecycleStart:` from within the callback of the `ACPCore::start:` method in your app's `application:didFinishLaunchingWithOptions:` delegate method.
+1. Register the Lifecycle extension with the SDK Core by adding the following to your app's `application:didFinishLaunchingWithOptions:` delegate method. This will register the extension with Core and begin Lifecycle event processing:
+
+```swift
+func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    MobileCore.registerExtensions([Lifecycle.self, ...], {
+        ...
+    }
+}
+```
+
+2. Start Lifecycle data collection by calling `lifecycleStart:` from within the callback of the `MobileCore.registerExtensions` method in your app's `application:didFinishLaunchingWithOptions:` delegate method.
 
 If your iOS application supports background capabilities, your `application:didFinishLaunchingWithOptions:` method might be called when iOS launches your app in the background. If you do not want background launches to count towards your lifecycle metrics, then `lifecycleStart:` should only be called when the application state is not equal to `UIApplicationStateBackground`.
 
 ```swift
 func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
-    // register the lifecycle extension
-    ACPLifecycle.registerExtension();
-
-    let appState = application.applicationState;            
-    ACPCore.start {
-        // only start lifecycle if the application is not in the background    
+    let appState = application.applicationState
+    MobileCore.registerExtensions([Lifecycle.self, ...], {
         if appState != .background {
-            ACPCore.lifecycleStart(nil)
-        }    
-    }    
+        // only start lifecycle if the application is not in the background
+        MobileCore.lifecycleStart(additionalContextData: nil)
+        }
+    }
 }
 ```
 
-When launched, if your app is resuming from a backgrounded state, iOS might call your `applicationWillEnterForeground:` delegate method. You also need to call `lifecycleStart:`, but this time you do not need all of the supporting code that you used in `application:didFinishLaunchingWithOptions:`:
+3. When launched, if your app is resuming from a backgrounded state, iOS might call your `applicationWillEnterForeground:` delegate method. You also need to call `lifecycleStart:`, but this time you do not need all of the supporting code that you used in `application:didFinishLaunchingWithOptions:`:
 
 ```swift
-func applicationWillEnterForeground(_ application: UIApplication) {    
-    ACPCore.lifecycleStart(nil)
+func applicationWillEnterForeground(_ application: UIApplication) {
+    MobileCore.lifecycleStart(additionalContextData: nil)
 }
 ```
 
-When the app enters the background, pause Lifecycle data collection from your app's `applicationDidEnterBackground:` delegate method:
+In iOS 13 and later, for a scene-based application, use the `UISceneDelegate`'s `sceneWillEnterForeground` method as follows:
 
 ```swift
-func applicationDidEnterBackground(_ application: UIApplication) {    
-    ACPCore.lifecyclePause()
+func sceneWillEnterForeground(_ scene: UIScene) {
+    MobileCore.lifecycleStart(additionalContextData: nil)
 }
 ```
+
+For more information on handling foregrounding applications with Scenes, refer to Apple's documentation [here](https://developer.apple.com/documentation/uikit/app_and_environment/scenes/preparing_your_ui_to_run_in_the_foreground)
+
+4. When the app enters the background, pause Lifecycle data collection from your app's `applicationDidEnterBackground:` delegate method:
+
+```swift
+func applicationDidEnterBackground(_ application: UIApplication) {
+    MobileCore.lifecyclePause()
+}
+```
+
+In iOS 13 and later, for a scene-based application, use the `UISceneDelegate`'s `sceneDidEnterBackground` method as follows:
+
+```swift
+func sceneDidEnterBackground(_ scene: UIScene) {
+    MobileCore.lifecyclePause()
+}
+```
+
+For more information on handling backgrounding applications with Scenes, refer to Apple's documentation [here](https://developer.apple.com/documentation/uikit/app_and_environment/scenes/preparing_your_ui_to_run_in_the_background)
 
 #### Objective-C
 
-Start Lifecycle data collection by calling `lifecycleStart:` from within the callback of the `ACPCore::start:` method in your app's `application:didFinishLaunchingWithOptions:` delegate method.
+1. Register the Lifecycle extension with the SDK Core by adding the following to your app's `application:didFinishLaunchingWithOptions:` delegate method. This will register the extension with Core and begin Lifecycle event processing:
 
-If your iOS application supports background capabilities, you `application:didFinishLaunchingWithOptions:` method may be called when iOS launches your app in the background. If you do not want background launches to count towards your lifecycle metrics, then `lifecycleStart:` should only be called when the application state is not equal to `UIApplicationStateBackground`.
+```objectivec
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    // register the lifecycle extension
+[AEPMobileCore registerExtensions:@[AEPMobileLifecycle.class, ...] completion:^{
+    ...
+}];
+return YES;
+}
+```
+
+2. Start Lifecycle data collection by calling `lifecycleStart:` from within the callback of the `AEPMobileCore::registerExtensions:` method in your app's `application:didFinishLaunchingWithOptions:` delegate method.
+
+If your iOS application supports background capabilities, your `application:didFinishLaunchingWithOptions:` method might be called when iOS launches your app in the background. If you do not want background launches to count towards your lifecycle metrics, then `lifecycleStart:` should only be called when the application state is not equal to `UIApplicationStateBackground`.
 
 ```objectivec
 - (BOOL) application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-    // register the lifecycle extension
-    [ACPLifecycle registerExtension];
-
+    // register the lifecycle extension, and begin event processing with Core
     const UIApplicationState appState = application.applicationState;
-    [ACPCore start:^{
-        // only start lifecycle if the application is not in the background
-        if (appState != UIApplicationStateBackground) {
-            [ACPCore lifecycleStart:nil];
-        }
+    [AEPMobileCore registerExtensions:@[AEPMobileLifecycle.class, ...] completion:^{
+    // only start lifecycle if the application is not in the background
+    if (appState != UIApplicationStateBackground) {
+        [AEPMobileCore lifecycleStart:nil];
+    }
     }];
 }
 ```
 
-When launched, if your app is resuming from a backgrounded state, iOS may call your `applicationWillEnterForeground:` delegate method. You also need to call `lifecycleStart:`, but this time you do not need all of the supporting code that you used in `application:didFinishLaunchingWithOptions:`:
+3. When launched, if your app is resuming from a backgrounded state, iOS might call your `applicationWillEnterForeground:` delegate method. You also need to call `lifecycleStart:`, but this time you do not need all of the supporting code that you used in `application:didFinishLaunchingWithOptions:`:
 
 ```objectivec
 - (void) applicationWillEnterForeground:(UIApplication *)application {
-    [ACPCore lifecycleStart:nil];
+    [AEPMobileCore lifecycleStart:nil];
 }
 ```
 
-When the app enters the background, pause Lifecycle data collection from your app's `applicationDidEnterBackground:` delegate method:
+In iOS 13 and later, for a scene-based application, use the `UISceneDelegate`'s `sceneWillEnterForeground` method as follows:
 
 ```objectivec
- - (void) applicationDidEnterBackground:(UIApplication *)application {
-    [ACPCore lifecyclePause];
- }
+- (void) sceneWillEnterForeground:(UIScene *)scene {
+    [AEPMobileCore lifecycleStart:nil];
+}
 ```
+
+For more information on handling foregrounding applications with Scenes, refer to Apple's documentation [here](https://developer.apple.com/documentation/uikit/app_and_environment/scenes/preparing_your_ui_to_run_in_the_foreground)
+
+4. When the app enters the background, pause Lifecycle data collection from your app's `applicationDidEnterBackground:` delegate method:
+
+```objectivec
+- (void) applicationDidEnterBackground:(UIApplication *)application {
+    [AEPMobileCore lifecyclePause];
+}
+```
+
+In iOS 13 and later, for a scene-based application, use the `UISceneDelegate`'s `sceneDidEnterBackground` method as follows:
+
+```objectivec
+- (void) sceneDidEnterBackground:(UIScene *)scene {
+    [AEPMobileCore lifecyclePause];
+}
+```
+
+For more information on handling backgrounding applications with Scenes, refer to Apple's documentation [here](https://developer.apple.com/documentation/uikit/app_and_environment/scenes/preparing_your_ui_to_run_in_the_background)
 
 <!-- <Variant platform="react-native" task="metrics" repeat="6"/>
 


### PR DESCRIPTION
Our Lifecycle metrics section was still referencing ACP APIs. I have updated it to match our current Lifecycle implementation examples.