### PR TITLE
Add Android Edge Bridge v3 migration docs

### DIFF
--- a/src/pages/resources/migration/android/migrate-to-3x.md
+++ b/src/pages/resources/migration/android/migrate-to-3x.md
@@ -99,3 +99,72 @@ Some of the APIs available in previous major versions of the Mobile SDK for Andr
 <InlineAlert variant="warning" slots="text"/>
 
 The `registerExtension` API for each extension that was deprecated in the 2.x version of the mobile SDK has been removed in the 3.x version of the mobile SDK. See the [Update SDK initialization](#update-sdk-initialization) section for more details.
+
+#### Edge Bridge
+
+As of version 3.0.0 of the Adobe Experience Platform Edge Bridge for Android, the table below shows how the `trackAction` and `trackState` parameters map to the `data` node of the Experience Event sent to the Experience Platform Edge Network. Edge Network automatically maps these data variables to Adobe Analytics without additional server-side configuration. If you are using Edge Bridge version 2.x and mapping data to XDM in your datastream, adjustments are required for version 3.0.0.
+
+| Data | Key path in v2.x | Key path in v3.+ | Description |
+| --- | --- | --- | --- |
+| Action | `data.action` | `data.__adobe.analytics.linkName` | As of v3, set as the custom link name in the Analytics hit. The field `data.__adobe.analytics.linkType` with value `other` is also automatically included. |
+| State | `data.state` | `data.__adobe.analytics.pageName` | As of v3, set as the page name in the Analytics hit. |
+| Context data | `data.contextdata` | `data.__adobe.analytics.contextData` | Context data is a map which includes the custom keys and values specified in the `trackAction` and `trackState` API calls. |
+| Context data prefixed with "&&" | `data.contextdata`| `data.__adobe.analytics` | Before v3, there was no special handling of context data prefixed with "&&".  <br/> <br/>  As of v3, context data keys prefixed with "&&" are automatically mapped to Analytics variables and no longer include the "&&" prefix. For example, the key `&&products` is sent as `data.__adobe.analytics.products`. Please note that these keys must be known to Analytics and are case sensitive. Find the full list of supported Analytics variables [here](https://experienceleague.adobe.com/en/docs/analytics/implementation/aep-edge/data-var-mapping). |
+| App identifier | Not included | `data.__adobe.analytics.contextData.a.AppID` | As of v3, the application identifier is automatically added to every tracking event under the key name `a.AppID`.|
+| Customer perspective | Not included|  `data.__adobe.analytics.cp` | As of v3, the customer perspective is automatically added to every tracking event. The values are either `foreground` or `background`. |
+
+##### Track action example
+
+Given the track action call:
+
+```kotlin
+MobileCore.trackAction("action name", mapOf("key" to "value", "&&products" to ";Running Shoes;1;69.95;event1|event2=55.99;eVar1=12345"))
+```
+
+The resulting Experience Event has the following payload:
+
+```json
+{
+  "data":{
+    "__adobe": {
+      "analytics": {
+        "linkName": "action name",
+        "linkType": "other",
+        "cp": "foreground",
+        "products": ";Running Shoes;1;69.95;event1|event2=55.99;eVar1=12345",
+        "contextData":{
+          "a.AppID": "myApp 1.0 (1)",
+          "key": "value"
+        }
+      }
+    }
+  }
+}
+```
+
+##### Track state example
+
+Given the track state call:
+
+```kotlin
+MobileCore.trackState("view name", mapOf("&&events" to "event5,event2=2"))
+```
+
+ The resulting Experience Event has the following payload:
+
+```json
+{
+  "data":{
+    "__adobe": {
+      "analytics": {
+        "pageName": "view name",
+        "cp": "foreground",
+        "events": "event5,event2=2",
+        "contextData":{
+          "a.AppID": "myApp 1.0 (1)"
+        }
+      }
+    }
+  }
+}
+```

--- a/src/pages/resources/migration/android/migrate-to-3x.md
+++ b/src/pages/resources/migration/android/migrate-to-3x.md
@@ -49,7 +49,7 @@ If you have implemented Adobe Experience Platform 2.x SDKs for Android, then thi
 
 1. [Update dependencies](#update-dependencies)
 2. [Update SDK initialization](#update-sdk-initialization)
-3. [Update outdated API references](#update-outdated-api-references)
+3. [Handle API migration and breaking changes](#handle-api-migration-and-breaking-changes)
 
 ### Update dependencies
 
@@ -92,7 +92,7 @@ If you are importing SDK libraries manually, make sure to update your libraries 
 
 The `MobileCore.start()` API and the `registerExtension` API for each extension, which were deprecated in the 2.x version of the mobile SDK, have been removed in the 3.x version. If you're still using these APIs, refer [here](./migrate-to-2x.md#update-sdk-initialization) to initialize the SDK and register the extensions using the `MobileCore.registerExtensions()` API.
 
-### API migration and breaking changes
+### Handle API migration and breaking changes
 
 Some of the APIs available in previous major versions of the Mobile SDK for Android are now deprecated or removed. You can choose to replace the obsolete APIs in your code with the alternative APIs in the 3.x version, as described below.
 

--- a/src/pages/resources/migration/android/migrate-to-3x.md
+++ b/src/pages/resources/migration/android/migrate-to-3x.md
@@ -102,7 +102,7 @@ The `registerExtension` API for each extension that was deprecated in the 2.x ve
 
 #### Edge Bridge
 
-As of version 3.0.0 of Adobe Experience Platform Edge Bridge for Android, the table below shows how the `trackAction` and `trackState` parameters map to the `data` node of the Experience Event sent to Experience Platform Edge Network. Edge Network automatically maps these data variables to Analytics without additional server-side configuration. If you are using Edge Bridge version 2.x and mapping data to XDM in your datastream, adjustments are required for version 3.0.0.
+As of version 3.0.0 of the Adobe Experience Platform Edge Bridge for Android, the table below shows how the `trackAction` and `trackState` parameters map to the `data` node of the Experience Event sent to the Experience Platform Edge Network. Edge Network automatically maps these data variables to Adobe Analytics without additional server-side configuration. If you are using Edge Bridge version 2.x and mapping data to XDM in your datastream, adjustments are required for version 3.0.0.
 
 | Data | Key path in v2.x | Key path in v3.+ | Description |
 | --- | --- | --- | --- |

--- a/src/pages/resources/migration/android/migrate-to-3x.md
+++ b/src/pages/resources/migration/android/migrate-to-3x.md
@@ -92,7 +92,7 @@ If you are importing SDK libraries manually, make sure to update your libraries 
 
 The `MobileCore.start()` API and the `registerExtension` API for each extension, which were deprecated in the 2.x version of the mobile SDK, have been removed in the 3.x version. If you're still using these APIs, refer [here](./migrate-to-2x.md#update-sdk-initialization) to initialize the SDK and register the extensions using the `MobileCore.registerExtensions()` API.
 
-### Update outdated API references
+### API migration and breaking changes
 
 Some of the APIs available in previous major versions of the Mobile SDK for Android are now deprecated or removed. You can choose to replace the obsolete APIs in your code with the alternative APIs in the 3.x version, as described below.
 

--- a/src/pages/resources/migration/android/migrate-to-3x.md
+++ b/src/pages/resources/migration/android/migrate-to-3x.md
@@ -102,7 +102,7 @@ The `registerExtension` API for each extension that was deprecated in the 2.x ve
 
 #### Edge Bridge
 
-As of version 3.0.0 of the Adobe Experience Platform Edge Bridge for Android, the table below shows how the `trackAction` and `trackState` parameters map to the `data` node of the Experience Event sent to the Experience Platform Edge Network. Edge Network automatically maps these data variables to Adobe Analytics without additional server-side configuration. If you are using Edge Bridge version 2.x and mapping data to XDM in your datastream, adjustments are required for version 3.0.0.
+As of version 3.0.0 of Adobe Experience Platform Edge Bridge for Android, the table below shows how the `trackAction` and `trackState` parameters map to the `data` node of the Experience Event sent to Experience Platform Edge Network. Edge Network automatically maps these data variables to Analytics without additional server-side configuration. If you are using Edge Bridge version 2.x and mapping data to XDM in your datastream, adjustments are required for version 3.0.0.
 
 | Data | Key path in v2.x | Key path in v3.+ | Description |
 | --- | --- | --- | --- |

--- a/src/pages/resources/migration/ios/migrate-to-5x.md
+++ b/src/pages/resources/migration/ios/migrate-to-5x.md
@@ -76,7 +76,8 @@ When updating to the Experience Platform 5.x SDKs, please take note of the follo
 
 ### Edge Bridge
 
-As of version 5.0.0 of the Adobe Experience Platform Edge Bridge for iOS, the table below shows how the `trackAction` and `trackState` parameters map to the `data` node of the Experience Event sent to the Experience Platform Edge Network. Edge Network automatically maps these data variables to Adobe Analytics without additional server-side configuration. If you are using Edge Bridge version 4.x and mapping data to XDM in your datastream, adjustments are required for version 5.0.0.
+As of version 5.0.0 of Adobe Experience Platform Edge Bridge for iOS, the table below shows how the `trackAction` and `trackState` parameters map to the `data` node of the Experience Event sent to Experience Platform Edge Network. Edge Network automatically maps these data variables to Analytics without additional server-side configuration. If you are using Edge Bridge version 4.x and mapping data to XDM in your datastream, adjustments are required for version 5.0.0.
+
 
 | Data | Key path in v4.x | Key path in v5.+ | Description |
 | --- | --- | --- | --- |

--- a/src/pages/resources/migration/ios/migrate-to-5x.md
+++ b/src/pages/resources/migration/ios/migrate-to-5x.md
@@ -70,7 +70,7 @@ Once the previous command is complete, run `pod install` or `pod update` to upda
 
 If you are using Swift Package Manger (SPM) for managing your app dependencies, you can now include the Experience Platform 5.x SDKs either through Xcode UI, or by declaring them as dependencies in the Package.swift project file. For more details, follow the guide for [managing dependencies using Swift Package Manager](../../manage-spm-dependencies.md).
 
-## Update outdated API references
+## API migration and breaking changes
 
 When updating to the Experience Platform 5.x SDKs, please take note of the following updates for API references.
 

--- a/src/pages/resources/migration/ios/migrate-to-5x.md
+++ b/src/pages/resources/migration/ios/migrate-to-5x.md
@@ -80,7 +80,7 @@ As of version 5.0.0 of the Adobe Experience Platform Edge Bridge for iOS, the ta
 
 | Data | Key path in v4.x | Key path in v5.+ | Description |
 | --- | --- | --- | --- |
-| Action | `data.action` | `data.__adobe.analytics.linkName` | As of v5, set as the custom link name in the Analytics hit. The field `data.__adobe.analytics.linkType` with value `lnk_o` is also automatically included. |
+| Action | `data.action` | `data.__adobe.analytics.linkName` | As of v5, set as the custom link name in the Analytics hit. The field `data.__adobe.analytics.linkType` with value `other` is also automatically included. |
 | State | `data.state` | `data.__adobe.analytics.pageName` | As of v5, set as the page name in the Analytics hit. |
 | Context data | `data.contextdata` | `data.__adobe.analytics.contextData` | Context data is a map which includes the custom keys and values specified in the `trackAction` and `trackState` API calls. |
 | Context data prefixed with "&&" | `data.contextdata`| `data.__adobe.analytics` | Before v5, there was no special handling of context data prefixed with "&&".  <br/> <br/>  As of v5, context data keys prefixed with "&&" are automatically mapped to Analytics variables and no longer include the "&&" prefix. For example, the key `&&products` is sent as `data.__adobe.analytics.products`. Please note that these keys must be known to Analytics and are case sensitive. Find the full list of supported Analytics variables [here](https://experienceleague.adobe.com/en/docs/analytics/implementation/aep-edge/data-var-mapping). |
@@ -103,7 +103,7 @@ The resulting Experience Event has the following payload:
     "__adobe": {
       "analytics": {
         "linkName": "action name",
-        "linkType": "lnk_o",
+        "linkType": "other",
         "cp": "foreground",
         "products": ";Running Shoes;1;69.95;event1|event2=55.99;eVar1=12345",
         "contextData":{

--- a/src/pages/resources/migration/ios/migrate-to-5x.md
+++ b/src/pages/resources/migration/ios/migrate-to-5x.md
@@ -76,8 +76,7 @@ When updating to the Experience Platform 5.x SDKs, please take note of the follo
 
 ### Edge Bridge
 
-As of version 5.0.0 of Adobe Experience Platform Edge Bridge for iOS, the table below shows how the `trackAction` and `trackState` parameters map to the `data` node of the Experience Event sent to Experience Platform Edge Network. Edge Network automatically maps these data variables to Analytics without additional server-side configuration. If you are using Edge Bridge version 4.x and mapping data to XDM in your datastream, adjustments are required for version 5.0.0.
-
+As of version 5.0.0 of the Adobe Experience Platform Edge Bridge for iOS, the table below shows how the `trackAction` and `trackState` parameters map to the `data` node of the Experience Event sent to the Experience Platform Edge Network. Edge Network automatically maps these data variables to Adobe Analytics without additional server-side configuration. If you are using Edge Bridge version 4.x and mapping data to XDM in your datastream, adjustments are required for version 5.0.0.
 
 | Data | Key path in v4.x | Key path in v5.+ | Description |
 | --- | --- | --- | --- |

--- a/src/pages/resources/migration/ios/migrate-to-5x.md
+++ b/src/pages/resources/migration/ios/migrate-to-5x.md
@@ -35,7 +35,7 @@ This Mobile SDK version for iOS now supports a minimum iOS version of 12.0 and a
 If you have implemented Adobe Experience Platform 4.x SDKs for iOS, then this guide will help you understand the steps required to migrate your implementation to the Experience Platform 5.x SDKs. In summary, you'll need to:
 
 1. [Update dependencies](#update-dependencies)
-2. [Update outdated API references](#update-outdated-api-references)
+2. [Handle API migration and breaking changes](#handle-api-migration-and-breaking-changes)
 
 ### Update dependencies
 
@@ -70,7 +70,7 @@ Once the previous command is complete, run `pod install` or `pod update` to upda
 
 If you are using Swift Package Manger (SPM) for managing your app dependencies, you can now include the Experience Platform 5.x SDKs either through Xcode UI, or by declaring them as dependencies in the Package.swift project file. For more details, follow the guide for [managing dependencies using Swift Package Manager](../../manage-spm-dependencies.md).
 
-## API migration and breaking changes
+## Handle API migration and breaking changes
 
 When updating to the Experience Platform 5.x SDKs, please take note of the following updates for API references.
 

--- a/src/pages/solution/adobe-analytics/migrate-to-edge-network.md
+++ b/src/pages/solution/adobe-analytics/migrate-to-edge-network.md
@@ -37,7 +37,7 @@ Other foundational extensions include the [Consent for Edge Network extension](.
 
 | Steps  |  Edge Network extension | Edge Bridge extension |
 | ----------- | ----------- | ----------- |
-| 1. [Set up an XDM schema](https://experienceleague.adobe.com/docs/experience-platform/xdm/home.html). Experience Data Model (XDM) is the open and publicly documented data model standard created by Adobe to standardize data collection, and is used across applications that leverage Experience Platform. <br/> **NOTE:** Take advantage of [automatic Analytics variable mapping](https://experienceleague.adobe.com/docs/analytics/implementation/aep-edge/variable-mapping.html) of XDM fields to Analytics dimensions by using the Adobe managed XDM schemas for Lifecycle, Media, Commerce, and more.| ✅  | ✅ |
+| 1. [Set up an XDM schema](https://experienceleague.adobe.com/docs/experience-platform/xdm/home.html). Experience Data Model (XDM) is the open and publicly documented data model standard created by Adobe to standardize data collection, and is used across applications that leverage Experience Platform. <br/> **NOTE:** Take advantage of [automatic Analytics variable mapping](https://experienceleague.adobe.com/docs/analytics/implementation/aep-edge/variable-mapping.html) of XDM fields to Analytics dimensions by using the Adobe managed XDM schemas for Lifecycle, Media, Commerce, and more.| ✅  |  |
 | 2. [Configure a datastream](https://experienceleague.adobe.com/docs/experience-platform/edge/datastreams/overview.html). A datastream is the server-side configuration used when implementing the Experience Platform Mobile SDK. | ✅  | ✅ |
 | 3. **Add the Adobe Analytics service** to your datastream. The datastream controls both whether and how data is sent to Adobe Analytics. You will need your Analytics report suite ID (RSID) for this step.  | ✅ | ✅ |
 | 4. **Install the *Edge Network* and *Identity for Edge Network extensions*** in the mobile property (tag) in Data Collection UI, and set the datastream in the Edge Network extension configuration. |  ✅ | ✅ |
@@ -46,7 +46,7 @@ Other foundational extensions include the [Consent for Edge Network extension](.
 | 6. **Remove the Analytics extension** dependency and extension registration from your mobile app code. <br/> **NOTE:** You should still keep the Analytics extension installed in the mobile property (tag) to ensure published versions of your app (pre-migration) continue to work seamlessly. |  ✅ | ✅ |
 | 7 .**Use Edge.sendEvent API** to send data in XDM format to Edge Network based on the schema you have defined. |  ✅ |  |
 | 8. **Keep existing MobileCore.trackAction / MobileCore.trackState API calls** to send data in context data format to Experience Platform.|  | ✅ |
-| 9. **(Optional) Map your context data to XDM** in Data Prep for Data Collection if required for other services. Not required for Analytics.| | ✅ |
+| 9. **(Optional) Map your context data to XDM** in Data Prep for Data Collection if required for other services. Not required for Analytics. <br/> **Note:** Mapping using Data Prep for Data Collection requires an [XDM schema](https://experienceleague.adobe.com/docs/experience-platform/xdm/home.html) to be configured for your datastream.| | ✅ |
 
 ### Implement the Edge Network extension
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds Android Edge Bridge v3 migration guide to migrate-to-3x.md docs.
Fixes `linkType` with value of "other" in iOS migrate-to-5x.md docs.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
