### PR TITLE
[Release Notes Automation] several enhancements

### DIFF
--- a/.github/scripts/release_notes/android-release.js
+++ b/.github/scripts/release_notes/android-release.js
@@ -158,7 +158,7 @@ function buildGitHubInfo(artifactId, artifactVersion) {
         case "identity":
         case "signal":
             return {
-                repoName: `aepsdk-${artifactId}-android`,
+                repoName: `aepsdk-core-android`,
                 tagName: `v${artifactVersion}-${artifactId}`
             }
 

--- a/.github/scripts/release_notes/github-release.js
+++ b/.github/scripts/release_notes/github-release.js
@@ -95,11 +95,10 @@ async function fetchReleaseInfoWithTagName(token, owner, repo, tag) {
     };
 
     console.log(`request options: ${JSON.stringify(options)}`)
-
     return new Promise((resolve) => {
         let reqGet = https.request(options, function (res) {
             if (res.statusCode != 200) {
-                console.error(`Error: response statusCode: ${res.statusCode}, please check if the tag (${tag}) exists in Github repo.`)
+                throw Error(`Error: response statusCode: ${res.statusCode}, please check if the tag (${tag}) exists in Github repo.`)
             }
             console.log(`response statusCode: ${res.statusCode}`)
 

--- a/.github/scripts/release_notes/update-release-notes.js
+++ b/.github/scripts/release_notes/update-release-notes.js
@@ -103,7 +103,7 @@ function extractBOMTableContent(releaseNote) {
     return newLines
 }
 
-function trimEmptyItem(items) {
+function cleanupReleaseContent(items) {
     // Find the index of the first non-empty item
     const firstNonEmptyIndex = _.findIndex(items, item => item.trim() !== '');
 
@@ -116,14 +116,14 @@ function trimEmptyItem(items) {
     }
 
     // Return the array sliced from the first to the last non-empty item
-    return items.slice(firstNonEmptyIndex, lastNonEmptyIndex + 1);
+    const trimmedItems = items.slice(firstNonEmptyIndex, lastNonEmptyIndex + 1);
+    // If the first non-empty item is "-", replace it with "*"
+    return trimmedItems.map(item => item.replace(/^\s*-/, '*'))
 }
 
 function generateReleaseNoteSection(ISODateString, platform, extension, version, releaseNote) {
     let array = extractReleaseNotes(releaseNote)
-    // remove the empty lines
-    // array = array.filter(line => line.trim() != '')
-    array = trimEmptyItem(array)
+    array = cleanupReleaseContent(array)
     let releaseNoteSection = releaseNoteTemplateGenerator({
         date: convertISODateToRleaseDateFormat(ISODateString),
         title: `${platform} ${extension} ${version}`,
@@ -134,9 +134,7 @@ function generateReleaseNoteSection(ISODateString, platform, extension, version,
 
 function generateReleaseNoteSectionWithoutDateLine(platform, extension, version, releaseNote) {
     let array = extractReleaseNotes(releaseNote)
-    // remove the empty lines
-    // array = array.filter(line => line.trim() != '')
-    array = trimEmptyItem(array)
+    array = cleanupReleaseContent(array)
     let releaseNoteSection = releaseNoteWithoutDateTemplateGenerator({
         title: `${platform} ${extension} ${version}`,
         note: array.join('\n')

--- a/.github/scripts/release_notes/update-release-notes.js
+++ b/.github/scripts/release_notes/update-release-notes.js
@@ -15,6 +15,7 @@ const { fetchAndroidReleaseInfo } = require('./android-release');
 const { capitalizeFirstLetter, convertISODateToRleaseDateFormat, extractReleaseNotes } = require('./utils');
 const lodashTemplate = require('lodash.template');
 const fs = require("fs");
+const _ = require('lodash');
 
 const repoNames = [
     "aepsdk-roku",
@@ -102,10 +103,27 @@ function extractBOMTableContent(releaseNote) {
     return newLines
 }
 
+function trimEmptyItem(items) {
+    // Find the index of the first non-empty item
+    const firstNonEmptyIndex = _.findIndex(items, item => item.trim() !== '');
+
+    // Find the index of the last non-empty item
+    const lastNonEmptyIndex = _.findLastIndex(items, item => item.trim() !== '');
+
+    // If no non-empty items are found, return an empty array
+    if (firstNonEmptyIndex === -1 || lastNonEmptyIndex === -1) {
+        return [];
+    }
+
+    // Return the array sliced from the first to the last non-empty item
+    return items.slice(firstNonEmptyIndex, lastNonEmptyIndex + 1);
+}
+
 function generateReleaseNoteSection(ISODateString, platform, extension, version, releaseNote) {
     let array = extractReleaseNotes(releaseNote)
     // remove the empty lines
-    array = array.filter(line => line.trim() != '')
+    // array = array.filter(line => line.trim() != '')
+    array = trimEmptyItem(array)
     let releaseNoteSection = releaseNoteTemplateGenerator({
         date: convertISODateToRleaseDateFormat(ISODateString),
         title: `${platform} ${extension} ${version}`,
@@ -117,7 +135,8 @@ function generateReleaseNoteSection(ISODateString, platform, extension, version,
 function generateReleaseNoteSectionWithoutDateLine(platform, extension, version, releaseNote) {
     let array = extractReleaseNotes(releaseNote)
     // remove the empty lines
-    array = array.filter(line => line.trim() != '')
+    // array = array.filter(line => line.trim() != '')
+    array = trimEmptyItem(array)
     let releaseNoteSection = releaseNoteWithoutDateTemplateGenerator({
         title: `${platform} ${extension} ${version}`,
         note: array.join('\n')


### PR DESCRIPTION
1. Remove any additional empty lines at the start and end of the release notes.
2. Bug fix for collecting the Android core extensions' release notes.
3. For unordered lists, always use the `*` in front of the line item.