### PR TITLE
update the Android migration docs

### DIFF
--- a/src/pages/resources/migration/android/migrate-to-2x.md
+++ b/src/pages/resources/migration/android/migrate-to-2x.md
@@ -146,6 +146,16 @@ The `registerExtension` API for each extension is deprecated in the 2.x version 
 | com.adobe.marketing.mobile.PlacesPOI | Moved into **places** subpackage. Update import statements to reference **com.adobe.marketing.mobile.places.PlacesPOI** |
 | com.adobe.marketing.mobile.PlacesRequestError | Moved into **places** subpackage. Update import statements to reference **com.adobe.marketing.mobile.places.PlacesRequestError** |
 
+### Network Override
+
+The helper classes for overriding the network service mentioned above have been removed in the 2.x version of the mobile SDK. If you had implemented code to override network services, you will need to update it refering to the guidance provided in this [documentation](https://developer.adobe.com/client-sdks/home/base/mobile-core/platform-services/network-service/).
+
+| Removed classes |
+| :------------- |
+| `AndroidNetworkServiceOverrider` |
+| `AndroidNetworkServiceOverrider.HTTPConnectionPerformer` |
+| `AndroidNetworkServiceOverrider.Connecting` |
+
 ## Frequently asked questions
 
 ### Is there a change in minimum API level supported by Mobile SDK for Android?

--- a/src/pages/resources/migration/android/migrate-to-2x.md
+++ b/src/pages/resources/migration/android/migrate-to-2x.md
@@ -148,13 +148,13 @@ The `registerExtension` API for each extension is deprecated in the 2.x version 
 
 ### Network Override
 
-The helper classes for overriding the network service mentioned above have been removed in the 2.x version of the mobile SDK. If you had implemented code to override network services, you will need to update it refering to the guidance provided in this [documentation](https://developer.adobe.com/client-sdks/home/base/mobile-core/platform-services/network-service/).
+The helper classes mentioned below for overriding the network service have been removed starting in the 2.x version of the mobile SDK. If you have implemented code to override network services, you will need to update it according to the guidance provided in this [documentation](https://developer.adobe.com/client-sdks/home/base/mobile-core/platform-services/network-service/).
 
-| Removed classes |
-| :------------- |
-| `AndroidNetworkServiceOverrider` |
-| `AndroidNetworkServiceOverrider.HTTPConnectionPerformer` |
-| `AndroidNetworkServiceOverrider.Connecting` |
+#### Removed classes
+
+- `AndroidNetworkServiceOverrider`
+- `AndroidNetworkServiceOverrider.HTTPConnectionPerformer`
+- `AndroidNetworkServiceOverrider.Connecting`
 
 ## Frequently asked questions
 

--- a/src/pages/resources/migration/android/migrate-to-2x.md
+++ b/src/pages/resources/migration/android/migrate-to-2x.md
@@ -152,9 +152,9 @@ The helper classes mentioned below for overriding the network service have been 
 
 #### Removed classes
 
-- `AndroidNetworkServiceOverrider`
-- `AndroidNetworkServiceOverrider.HTTPConnectionPerformer`
-- `AndroidNetworkServiceOverrider.Connecting`
+* `AndroidNetworkServiceOverrider`
+* `AndroidNetworkServiceOverrider.HTTPConnectionPerformer`
+* `AndroidNetworkServiceOverrider.Connecting`
 
 ## Frequently asked questions
 


### PR DESCRIPTION
The Android SDK 2.x has a breaking change for the `network override` use case, which we missed mentioning in the migration docs. 
The iOS SDK also has a similar breaking change in the latest versions. I will update the iOS migration docs in another PR since it's sitting in the acp doc repo. https://developer.adobe.com/client-sdks/previous-versions/documentation/mobile-core/migration/