### PR TITLE
Correct Kotlin version compatibility for Android 3.x  release notes

### DIFF
--- a/src/pages/home/base/assurance/release-notes.md
+++ b/src/pages/home/base/assurance/release-notes.md
@@ -22,7 +22,7 @@ keywords:
 
 ### Android Assurance 3.0.3
 
-* Removed `app_name` string resource to prevent conflicts with resources defined by the app. 
+* Removed `app_name` string resource to prevent conflicts with resources defined by the app.
 
 ## August 12, 2024
 

--- a/src/pages/home/base/assurance/release-notes.md
+++ b/src/pages/home/base/assurance/release-notes.md
@@ -91,7 +91,7 @@ Major version update for [Assurance](https://github.com/adobe/aepsdk-react-nativ
 Major version update for [Adobe Experience Platform Assurance](./index.md) on Android compatible with Mobile Core 3.0.0. The current release includes the following changes:
 
 * Updated the minimum supported Android API level to 21.
-* The SDK is now compatible with Kotlin 1.5 and higher.
+* The SDK is now compatible with Kotlin 1.8 and higher.
 * Removed deprecated `registerExtension` API. Use the `MobileCore.registerExtensions()` API for registering extensions and initializing the SDK instead.
 * Migrated SDK UI components to Jetpack Compose.
 

--- a/src/pages/home/base/mobile-core/release-notes.md
+++ b/src/pages/home/base/mobile-core/release-notes.md
@@ -191,7 +191,7 @@ To learn how Apple's privacy related announcements made in WWDC of 2023 affect t
 Major version update for [Signal](./signal/index.md) for Adobe Experience Platform Mobile SDKs on Android compatible with Mobile Core 3.0.0. The current release includes the following changes:
 
 * Updated the minimum supported Android API level to 21.
-* The SDK is now compatible with Kotlin 1.5 and higher.
+* The SDK is now compatible with Kotlin 1.8 and higher.
 * Removed deprecated `registerExtension` API. Use the MobileCore.registerExtensions() API for registering extensions and initializing the SDK instead.
 * Added an enhancement to prevent network retries when the device's network is offline.
 
@@ -217,7 +217,7 @@ Major version update of Adobe Experience Platform Core Android SDK is live!
 Please note that the current release includes the following changes:
 
 * Updated the minimum supported Android API level to 21.
-* The SDK is now compatible with Kotlin 1.5 and higher.
+* The SDK is now compatible with Kotlin 1.8 and higher.
 * Migrated UI service to use Jetpack Compose.
 * Removed deprecated `MobileCore.registerExtension(...)` and `MobileCore.start()` APIs. Use the `MobileCore.registerExtensions(...)` API for registering extensions and initializing the SDK instead.
 * Removed `MobileCore.setMessagingDelegate`, `MobileCore.getMessagingDelegate` APIs which were used to control the display of in-app messages. Migrate to `com.adobe.marketing.mobile.services.ui.PresentationDelegate` and use `ServiceProvider.getUIService().setPresentationDelegate` API instead.

--- a/src/pages/home/release-notes/2024.md
+++ b/src/pages/home/release-notes/2024.md
@@ -1398,7 +1398,7 @@ Major version update for [Assurance](https://github.com/adobe/aepsdk-react-nativ
 New major version of the Mobile Core SDK for Android has been released along with updates to other extensions. The current release includes the following changes:
 
 * Updated the minimum supported Android API level to 21.
-* The SDK is now compatible with Kotlin 1.5 and higher.
+* The SDK is now compatible with Kotlin 1.8 and higher.
 * Added an enhancement to prevent network retries when the device's network is offline.
 * Migrated UI service to use Jetpack Compose.
 
@@ -1556,7 +1556,7 @@ Major version update for [Adobe Audience Manager](../../solution/adobe-audience-
 Major version update for [Campaign Classic](../../solution/adobe-campaign-classic/index.md) for Adobe Experience Platform Mobile SDKs on Android compatible with Mobile Core 3.0.0. The current release includes the following changes:
 
 * Updated the minimum supported Android API level to 21.
-* The SDK is now compatible with Kotlin 1.5 and higher.
+* The SDK is now compatible with Kotlin 1.8 and higher.
 * Removed the out-of-the-box push template handling code. This functionality will be available in a future Core 3.x release.
 
 ### Android Campaign Standard 3.0.0
@@ -1564,7 +1564,7 @@ Major version update for [Campaign Classic](../../solution/adobe-campaign-classi
 Major version update for [Campaign Standard](../../solution/adobe-campaign-standard/index.md) for Adobe Experience Platform Mobile SDKs on Android compatible with Mobile Core 3.0.0. The current release includes the following changes:
 
 * Updated the minimum supported Android API level to 21.
-* The SDK is now compatible with Kotlin 1.5 and higher.
+* The SDK is now compatible with Kotlin 1.8 and higher.
 * Removed deprecated `registerExtension` API. Use the MobileCore.registerExtensions() API for registering extensions and initializing the SDK instead.
 * Migrated Campaign SDK to use Jetpack Compose based UI Services from MobileCore 3.0.0
 * Moved code to create and track local notifications from Mobile Core to Campaign.
@@ -1593,7 +1593,7 @@ Major version update of Adobe Experience Platform Core Android SDK is live!
 Please note that the current release includes the following changes:
 
 * Updated the minimum supported Android API level to 21.
-* The SDK is now compatible with Kotlin 1.5 and higher.
+* The SDK is now compatible with Kotlin 1.8 and higher.
 * Migrated UI service to use Jetpack Compose.
 * Removed deprecated `MobileCore.registerExtension(...)` and `MobileCore.start()` APIs. Use the `MobileCore.registerExtensions(...)` API for registering extensions and initializing the SDK instead.
 * Removed `MobileCore.setMessagingDelegate`, `MobileCore.getMessagingDelegate` APIs which were used to control the display of in-app messages. Migrate to `com.adobe.marketing.mobile.services.ui.PresentationDelegate` and use `ServiceProvider.getUIService().setPresentationDelegate` API instead.
@@ -1605,7 +1605,7 @@ Please note that the current release includes the following changes:
 Major version update for [Signal](../base/mobile-core/signal/index.md) for Adobe Experience Platform Mobile SDKs on Android compatible with Mobile Core 3.0.0. The current release includes the following changes:
 
 * Updated the minimum supported Android API level to 21.
-* The SDK is now compatible with Kotlin 1.5 and higher.
+* The SDK is now compatible with Kotlin 1.8 and higher.
 * Removed deprecated `registerExtension` API. Use the MobileCore.registerExtensions() API for registering extensions and initializing the SDK instead.
 * Added an enhancement to prevent network retries when the device's network is offline.
 
@@ -1638,7 +1638,7 @@ Major version update for [User Profile](../base/profile/index.md) for Adobe Expe
 Major version update for [Adobe Experience Platform Assurance](../base/assurance/index.md) on Android compatible with Mobile Core 3.0.0. The current release includes the following changes:
 
 * Updated the minimum supported Android API level to 21.
-* The SDK is now compatible with Kotlin 1.5 and higher.
+* The SDK is now compatible with Kotlin 1.8 and higher.
 * Removed deprecated `registerExtension` API. Use the `MobileCore.registerExtensions()` API for registering extensions and initializing the SDK instead.
 * Migrated SDK UI components to Jetpack Compose.
 

--- a/src/pages/home/release-notes/index.md
+++ b/src/pages/home/release-notes/index.md
@@ -1442,7 +1442,7 @@ Major version update for [Assurance](https://github.com/adobe/aepsdk-react-nativ
 New major version of the Mobile Core SDK for Android has been released along with updates to other extensions. The current release includes the following changes:
 
 * Updated the minimum supported Android API level to 21.
-* The SDK is now compatible with Kotlin 1.5 and higher.
+* The SDK is now compatible with Kotlin 1.8 and higher.
 * Added an enhancement to prevent network retries when the device's network is offline.
 * Migrated UI service to use Jetpack Compose.
 
@@ -1600,7 +1600,7 @@ Major version update for [Adobe Audience Manager](../../solution/adobe-audience-
 Major version update for [Campaign Classic](../../solution/adobe-campaign-classic/index.md) for Adobe Experience Platform Mobile SDKs on Android compatible with Mobile Core 3.0.0. The current release includes the following changes:
 
 * Updated the minimum supported Android API level to 21.
-* The SDK is now compatible with Kotlin 1.5 and higher.
+* The SDK is now compatible with Kotlin 1.8 and higher.
 * Removed the out-of-the-box push template handling code. This functionality will be available in a future Core 3.x release.
 
 ### Android Campaign Standard 3.0.0
@@ -1608,7 +1608,7 @@ Major version update for [Campaign Classic](../../solution/adobe-campaign-classi
 Major version update for [Campaign Standard](../../solution/adobe-campaign-standard/index.md) for Adobe Experience Platform Mobile SDKs on Android compatible with Mobile Core 3.0.0. The current release includes the following changes:
 
 * Updated the minimum supported Android API level to 21.
-* The SDK is now compatible with Kotlin 1.5 and higher.
+* The SDK is now compatible with Kotlin 1.8 and higher.
 * Removed deprecated `registerExtension` API. Use the MobileCore.registerExtensions() API for registering extensions and initializing the SDK instead.
 * Migrated Campaign SDK to use Jetpack Compose based UI Services from MobileCore 3.0.0
 * Moved code to create and track local notifications from Mobile Core to Campaign.
@@ -1637,7 +1637,7 @@ Major version update of Adobe Experience Platform Core Android SDK is live!
 Please note that the current release includes the following changes:
 
 * Updated the minimum supported Android API level to 21.
-* The SDK is now compatible with Kotlin 1.5 and higher.
+* The SDK is now compatible with Kotlin 1.8 and higher.
 * Migrated UI service to use Jetpack Compose.
 * Removed deprecated `MobileCore.registerExtension(...)` and `MobileCore.start()` APIs. Use the `MobileCore.registerExtensions(...)` API for registering extensions and initializing the SDK instead.
 * Removed `MobileCore.setMessagingDelegate`, `MobileCore.getMessagingDelegate` APIs which were used to control the display of in-app messages. Migrate to `com.adobe.marketing.mobile.services.ui.PresentationDelegate` and use `ServiceProvider.getUIService().setPresentationDelegate` API instead.
@@ -1649,7 +1649,7 @@ Please note that the current release includes the following changes:
 Major version update for [Signal](../base/mobile-core/signal/index.md) for Adobe Experience Platform Mobile SDKs on Android compatible with Mobile Core 3.0.0. The current release includes the following changes:
 
 * Updated the minimum supported Android API level to 21.
-* The SDK is now compatible with Kotlin 1.5 and higher.
+* The SDK is now compatible with Kotlin 1.8 and higher.
 * Removed deprecated `registerExtension` API. Use the MobileCore.registerExtensions() API for registering extensions and initializing the SDK instead.
 * Added an enhancement to prevent network retries when the device's network is offline.
 
@@ -1682,7 +1682,7 @@ Major version update for [User Profile](../base/profile/index.md) for Adobe Expe
 Major version update for [Adobe Experience Platform Assurance](../base/assurance/index.md) on Android compatible with Mobile Core 3.0.0. The current release includes the following changes:
 
 * Updated the minimum supported Android API level to 21.
-* The SDK is now compatible with Kotlin 1.5 and higher.
+* The SDK is now compatible with Kotlin 1.8 and higher.
 * Removed deprecated `registerExtension` API. Use the `MobileCore.registerExtensions()` API for registering extensions and initializing the SDK instead.
 * Migrated SDK UI components to Jetpack Compose.
 

--- a/src/pages/solution/adobe-campaign-classic/release-notes.md
+++ b/src/pages/solution/adobe-campaign-classic/release-notes.md
@@ -70,7 +70,7 @@ Add support for out-of-the-box push notifications:
 Major version update for [Campaign Classic](./index.md) for Adobe Experience Platform Mobile SDKs on Android compatible with Mobile Core 3.0.0. The current release includes the following changes:
 
 * Updated the minimum supported Android API level to 21.
-* The SDK is now compatible with Kotlin 1.5 and higher.
+* The SDK is now compatible with Kotlin 1.8 and higher.
 * Removed the out-of-the-box push template handling code. This functionality will be available in a future Core 3.x release.
 
 ## March 20, 2024

--- a/src/pages/solution/adobe-campaign-standard/release-notes.md
+++ b/src/pages/solution/adobe-campaign-standard/release-notes.md
@@ -37,7 +37,7 @@ Major version update for [Campaign Classic](https://github.com/adobe/aepsdk-reac
 Major version update for [Campaign Standard](./index.md) for Adobe Experience Platform Mobile SDKs on Android compatible with Mobile Core 3.0.0. The current release includes the following changes:
 
 * Updated the minimum supported Android API level to 21.
-* The SDK is now compatible with Kotlin 1.5 and higher.
+* The SDK is now compatible with Kotlin 1.8 and higher.
 * Removed deprecated `registerExtension` API. Use the MobileCore.registerExtensions() API for registering extensions and initializing the SDK instead.
 * Migrated Campaign SDK to use Jetpack Compose based UI Services from MobileCore 3.0.0
 * Moved code to create and track local notifications from Mobile Core to Campaign.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Kotlin version compatibility for our Android 3.x SDK's is listed incorrectly as `1.5` instead of `1.8`. This PR corrects occurrences of compatibility statement. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Kotlin version compatibility for our Android 3.x SDK's is listed in-correctly as `1.5` instead of `1.8`. This PR corrects occurrences of compatibility statement. 

## How Has This Been Tested?
- Find occurrences of Kotlin & Kotlin 1.5 to verify that they are replaced.
- `yarn dev` to see updated changes

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
