### PR TITLE
Fix Places behavior reference images using relative paths

### DIFF
--- a/src/pages/solution/places/behavior-reference.md
+++ b/src/pages/solution/places/behavior-reference.md
@@ -93,7 +93,7 @@ The original draw.io source file which contains all diagram pages is also includ
 - Transparent background
 - Appearance: Light (Dark mode is not currently supported, so dynamically switching SVGs perform worse.)
  -->
-![](/src/pages/solution/places/assets/behavior-reference/non-intersecting-enter-A.svg)
+![](./assets/behavior-reference/non-intersecting-enter-A.svg)
 
 #### Exit POI A
 
@@ -103,7 +103,7 @@ The user has exited the radius for POI A:
 * **Last Entered POI** remains unchanged as POI A.  
 * **Last Exited POI** is set to POI A.  
 
-![](/src/pages/solution/places/assets/behavior-reference/non-intersecting-exit-A.svg)
+![](./assets/behavior-reference/non-intersecting-exit-A.svg)
 
 #### Enter POI B
 
@@ -113,7 +113,7 @@ The user has entered the radius for POI B:
 * **Last Entered POI** is set to POI B.  
 * **Last Exited POI** remains unchanged as POI A.  
 
-![](/src/pages/solution/places/assets/behavior-reference/non-intersecting-enter-B.svg)
+![](./assets/behavior-reference/non-intersecting-enter-B.svg)
 
 ### Scenario: Intersecting points
 
@@ -125,7 +125,7 @@ The user has entered the radius for POI A:
 * **Last Entered POI** is set to POI A.  
 * **Last Exited POI** remains unchanged as none.  
 
-![](/src/pages/solution/places/assets/behavior-reference/intersecting-enter-A.svg)
+![](./assets/behavior-reference/intersecting-enter-A.svg)
 
 #### Enter POI B
 
@@ -136,7 +136,7 @@ The user has entered the radius for POI B:
 * **Last Entered POI** is set to POI B.  
 * **Last Exited POI** remains unchanged as none.  
 
-![](/src/pages/solution/places/assets/behavior-reference/intersecting-enter-B.svg)
+![](./assets/behavior-reference/intersecting-enter-B.svg)
 
 #### Exit POI A
 
@@ -147,4 +147,4 @@ The user has exited the radius for POI A:
 * **Last entered POI** remains unchanged and is set to POI B.  
 * **Last exited POI** is set to POI A.  
 
-![](/src/pages/solution/places/assets/behavior-reference/intersecting-exit-A.svg)
+![](./assets/behavior-reference/intersecting-exit-A.svg)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes the SVG image links in the Places behavior reference by using relative links instead of absolute.

Confirmation using dev build:
<img width="1782" alt="Screenshot 2025-03-13 at 6 51 20 PM" src="https://github.com/user-attachments/assets/ed796867-6416-454d-8d1a-bf04aca780b2" />


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
