### PR TITLE
[Improvement] update release note script to support windows line break (/r/n)

### DIFF
--- a/.github/scripts/release_notes/index.js
+++ b/.github/scripts/release_notes/index.js
@@ -18,6 +18,7 @@ const { fetchReleaseInfoFromGitHub, sortReleaseInfoByDateASC } = require('./fetc
 
 // Run the script on the root directory of the project: node .github/scripts/release_notes/index.js <GITHUB_TOKEN> [--dry-run]
 const GITHUB_TOKEN = process.argv[2];
+// const DEBUG_MODE = (process.argv[3] === "--debug")
 
 if (GITHUB_TOKEN === undefined) {
     throw new Error("token is undefined")

--- a/.github/scripts/release_notes/index.js
+++ b/.github/scripts/release_notes/index.js
@@ -18,7 +18,6 @@ const { fetchReleaseInfoFromGitHub, sortReleaseInfoByDateASC } = require('./fetc
 
 // Run the script on the root directory of the project: node .github/scripts/release_notes/index.js <GITHUB_TOKEN> [--dry-run]
 const GITHUB_TOKEN = process.argv[2];
-// const DEBUG_MODE = (process.argv[3] === "--debug")
 
 if (GITHUB_TOKEN === undefined) {
     throw new Error("token is undefined")

--- a/.github/scripts/release_notes/updateReleaseNotes.js
+++ b/.github/scripts/release_notes/updateReleaseNotes.js
@@ -16,7 +16,7 @@ const fs = require("fs");
 const _ = require('lodash');
 
 function extractBOMTableContent(releaseNote) {
-    let lines = releaseNote.split('\n');
+    let lines = releaseNote.split(/\r?\n/);
     let newLines = []
     for (const line of lines) {
         if (line.startsWith('|')) {
@@ -122,7 +122,7 @@ function generateReleaseNotesSectionWithoutDateLine(releaseInfo) {
 
 async function updateReleaseNotesPage(filePath, releaseInfoArray) {
     // Read the contents of the markdown file.
-    let contentLines = fs.readFileSync(filePath, "utf8").toString().split("\n")
+    let contentLines = fs.readFileSync(filePath, "utf8").toString().split(/\r?\n/)
     // Find the index of the release notes header.
     let releaseNotesHeader = "# Release notes"
     let releaseNotesHeaderIndex = contentLines.indexOf(releaseNotesHeader)
@@ -145,14 +145,14 @@ async function updateReleaseNotesPage(filePath, releaseInfoArray) {
         if (hasLineStartWith(dateLine, contentLines)) {
             let releaseNote = generateReleaseNotesSectionWithoutDateLine(releaseInfo)
             // generate the release notes section to array
-            let releaseNoteLines = releaseNote.split("\n");
+            let releaseNoteLines = releaseNote.split(/\r?\n/);
             let dateLineIndex = contentLines.indexOf(dateLine);
             contentLines.splice(dateLineIndex + 1, 0, ...releaseNoteLines)
             contentIsChanged = true
         } else {
             let releaseNote = generateReleaseNotesSection(releaseInfo)
             // generate the release notes section to array
-            let releaseNoteLines = releaseNote.split("\n");
+            let releaseNoteLines = releaseNote.split(/\r?\n/);
             contentLines.splice(releaseNotesHeaderIndex + 1, 0, ...releaseNoteLines)
             contentIsChanged = true
         }

--- a/.github/scripts/release_notes/utils.js
+++ b/.github/scripts/release_notes/utils.js
@@ -36,7 +36,7 @@ function extractReleaseNotes(releaseText) {
     if (!releaseText) {
         return []
     }
-    const lines = releaseText.split('\n');
+    const lines = releaseText.split(/\r?\n/);
     let start = -1
     let end = lines.length
 


### PR DESCRIPTION
In PR https://github.com/AdobeDocs/aep-mobile-sdkdocs/pull/794 (the corresponding commit https://github.com/AdobeDocs/aep-mobile-sdkdocs/commit/78dd341d11528c47674094f729c2cb09b45c28dd), the entire release notes [page](https://github.com/AdobeDocs/aep-mobile-sdkdocs/blob/main/src/pages/home/release-notes/index.md) was modified from using `/n` to `/r/n`. It may be caused by manually editing the Markdown file on a Windows machine. So, the release notes scripts need to be updated to accommodate the `/r/n` line break.
