### PR TITLE
[MOB-23117] Adding usage information for backgroundd colour of zero bezel push notification

### DIFF
--- a/src/pages/resources/reference/push-notifications/templates/tabs/zero-bezel.md
+++ b/src/pages/resources/reference/push-notifications/templates/tabs/zero-bezel.md
@@ -92,8 +92,7 @@ Custom sound files must be placed within the app's bundle in the `res/raw` direc
 
 #### Android
 
-- The background color can be customized for Android versions below 11
-- For Android 11 and above, the background color will be white by default and cannot be customized
-- The color should be specified in hex format (e.g., `#FF0000`)
-- The background color will be applied to the entire notification area
-
+* The background color can be customized for Android versions below 11
+* For Android 11 and above, the background color will be white by default and cannot be customized
+* The color should be specified in hex format (e.g., `#FF0000`)
+* The background color will be applied to the entire notification area

--- a/src/pages/resources/reference/push-notifications/templates/tabs/zero-bezel.md
+++ b/src/pages/resources/reference/push-notifications/templates/tabs/zero-bezel.md
@@ -90,8 +90,6 @@ Custom sound files must be placed within the app's bundle in the `res/raw` direc
 
 ### Background Color Specifications
 
-#### Android
-
 * The background color can be customized for Android versions below 11
 * For Android 11 and above, the background color will be white by default and cannot be customized
 * The color should be specified in hex format (e.g., `#FF0000`)

--- a/src/pages/resources/reference/push-notifications/templates/tabs/zero-bezel.md
+++ b/src/pages/resources/reference/push-notifications/templates/tabs/zero-bezel.md
@@ -24,7 +24,7 @@ The properties below define the payload sent to FCM:
 | Icon | ⛔️ | `adb_icon` | string | Name of a small icon to use in the notification. <br />**Note** - The value referenced by this key is not used if a valid `adb_small_icon` key value pair is present in the payload. |
 | Small Icon | ⛔️ | `adb_small_icon` | string | Name of a small icon to use in the notification. The app's drawable resources are checked for an image file with the provided name. |
 | Color - Small Icon | ⛔️ | `adb_clr_icon` | string | Color for the notification's small icon.<br />Represented as six character hex, e.g. `00FF00`. |
-| Channel ID | ⛔️ | `adb_channel_id` | string | The [notification's channel id](https://developer.android.com/guide/topics/ui/notifiers/notifications#ManageChannels) (new in Android O). The app must create a channel with this channel ID before any notification with this channel ID is received. If you don't send this channel ID in the request, or if the channel ID provided has not yet been created by the app, FCM uses the channel ID specified in the app manifest.<br />If not provided in payload, SDK uses a "default" channel ID of value "General Notifications".<br />If < API 26 (Android O), this value is ignored. |
+| Channel ID | ⛔️ | `adb_channel_id` | string | The [notification's channel id](https://developer.android.com/guide/topics/ui/notifiers/notifications#ManageChannels) (new in Android O). The app must create a channel with this channel ID before any notification with this channel ID is received. If you don't send this channel ID in the request, or if the channel ID provided has not yet been created by the app, FCM uses the channel ID specified in the app manifest.<br />If not provided in payload, SDK uses a "default" channel ID of value "General Notifications".<br />If < API 26 (Android O), this value is ignored. |
 | Badge Count | ⛔️ | `adb_n_count` | string | Value to be used on app's badge. |
 | Priority | ⛔️ | `adb_n_priority` | string | Designates the notification priority for Android - [importance](https://developer.android.com/reference/android/app/NotificationChannel#setImportance(int)) for API >= 26 (Android 8.0) or [priority](https://developer.android.com/reference/androidx/core/app/NotificationCompat.Builder#setPriority(int)) for API < 26. |
 | Tag | ⛔️ | `adb_tag` | string | Identifier used to replace existing notifications in the notification drawer. If not specified, each request creates a new notification. If specified and a notification with the same tag is already being shown, the new notification replaces the existing one in the notification drawer. |
@@ -87,3 +87,12 @@ Custom sound files must be placed within the app's bundle in the `res/raw` direc
 | :-------- | ------: | -------: |
 | Title | ~35 (depends on screen size and device font setting) | No |
 | Description | ~110 (depends on screen size and device font setting) | Yes |
+
+### Background Color Specifications
+
+#### Android
+- The background color can be customized for Android versions below 11
+- For Android 11 and above, the background color will be white by default and cannot be customized
+- The color should be specified in hex format (e.g., "#FF0000")
+- The background color will be applied to the entire notification area
+

--- a/src/pages/resources/reference/push-notifications/templates/tabs/zero-bezel.md
+++ b/src/pages/resources/reference/push-notifications/templates/tabs/zero-bezel.md
@@ -91,8 +91,9 @@ Custom sound files must be placed within the app's bundle in the `res/raw` direc
 ### Background Color Specifications
 
 #### Android
+
 - The background color can be customized for Android versions below 11
 - For Android 11 and above, the background color will be white by default and cannot be customized
-- The color should be specified in hex format (e.g., "#FF0000")
+- The color should be specified in hex format (e.g., `#FF0000`)
 - The background color will be applied to the entire notification area
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
