### PR TITLE
[test] verify no-dead-urls lint on brand-concierge link - do not merge

### DIFF
--- a/src/pages/home/release-notes/index.md
+++ b/src/pages/home/release-notes/index.md
@@ -7,6 +7,8 @@ Keywords:
 
 # Release notes
 
+<!-- test PR: verifying the no-dead-urls lint check against the business.adobe.com/products/brand-concierge.html link below. Not meant to be merged. -->
+
 ## July 8, 2026
 
 ### iOS EdgeIdentity 5.1.0


### PR DESCRIPTION
Test PR to trigger the v3 lint workflow against `src/pages/home/release-notes/index.md`, which contains the `https://business.adobe.com/products/brand-concierge.html` link previously flagged as a dead-link false positive (see #913). Checking whether the current v3 workflow's linter report flags it. Not meant to be merged.