### PR TITLE
[test/scratch] trigger v3 lint on release-notes to check brand-concierge dead-link

### DIFF
--- a/src/pages/home/release-notes/index.md
+++ b/src/pages/home/release-notes/index.md
@@ -7,6 +7,10 @@ Keywords:
 
 # Release notes
 
+## July 13, 2026
+
+Test entry to trigger the v3 lint workflow on this file (contains the existing `business.adobe.com/products/brand-concierge.html` links below) — scratch change, not a real release note.
+
 ## July 8, 2026
 
 ### iOS EdgeIdentity 5.1.0


### PR DESCRIPTION
Scratch test PR to trigger the v3 lint workflow (which now tracks adp-devsite-utils main, including PR #96's fix) against src/pages/home/release-notes/index.md, which already links to business.adobe.com/products/brand-concierge.html twice. Checking whether the linter report flags it as a dead link. Will close and delete branch after checking results. Not to be merged.